### PR TITLE
Add `Rect` and `Size` primitives and use them for layout

### DIFF
--- a/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
+++ b/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
@@ -32,24 +32,32 @@ public class AGGRenderer: Renderer{
                                     fontPath)
         initialized = true
     }
+    
+    func getPoints(from rect: Rect) -> (tL: Point, tR: Point, bL: Point, bR: Point) {
+        let rect = rect.normalized
+        return (
+            Point(rect.origin.x, rect.maxY),
+            Point(rect.maxX, rect.maxY),
+            rect.origin,
+            Point(rect.maxX, rect.origin.y)
+        )
+    }
 
-    public func drawRect(topLeftPoint p1: Point,
-                         topRightPoint p2: Point,
-                         bottomRightPoint p3: Point,
-                         bottomLeftPoint p4: Point,
+    public func drawRect(_ rect: Rect,
                          strokeWidth thickness: Float,
                          strokeColor: Color = Color.black,
                          isOriginShifted: Bool) {
         var x = [Float]()
         var y = [Float]()
-        x.append(p1.x + xOffset)
-        x.append(p2.x + xOffset)
-        x.append(p3.x + xOffset)
-        x.append(p4.x + xOffset)
-        y.append(p1.y + yOffset)
-        y.append(p2.y + yOffset)
-        y.append(p3.y + yOffset)
-        y.append(p4.y + yOffset)
+        let pts = getPoints(from: rect)
+        x.append(pts.tL.x + xOffset)
+        x.append(pts.tR.x + xOffset)
+        x.append(pts.bR.x + xOffset)
+        x.append(pts.bL.x + xOffset)
+        y.append(pts.tL.y + yOffset)
+        y.append(pts.tR.y + yOffset)
+        y.append(pts.bR.y + yOffset)
+        y.append(pts.bL.y + yOffset)
         draw_rect(x,
                   y,
                   thickness,
@@ -61,23 +69,21 @@ public class AGGRenderer: Renderer{
                   agg_object)
     }
 
-    public func drawSolidRect(topLeftPoint p1: Point,
-                              topRightPoint p2: Point,
-                              bottomRightPoint p3: Point,
-                              bottomLeftPoint p4: Point,
+    public func drawSolidRect(_ rect: Rect,
                               fillColor: Color = Color.white,
                               hatchPattern: BarGraphSeriesOptions.Hatching,
                               isOriginShifted: Bool) {
         var x = [Float]()
         var y = [Float]()
-        x.append(p1.x + xOffset)
-        x.append(p2.x + xOffset)
-        x.append(p3.x + xOffset)
-        x.append(p4.x + xOffset)
-        y.append(p1.y + yOffset)
-        y.append(p2.y + yOffset)
-        y.append(p3.y + yOffset)
-        y.append(p4.y + yOffset)
+        let pts = getPoints(from: rect)
+        x.append(pts.tL.x + xOffset)
+        x.append(pts.tR.x + xOffset)
+        x.append(pts.bR.x + xOffset)
+        x.append(pts.bL.x + xOffset)
+        y.append(pts.tL.y + yOffset)
+        y.append(pts.tR.y + yOffset)
+        y.append(pts.bR.y + yOffset)
+        y.append(pts.bL.y + yOffset)
         draw_solid_rect(x,
                         y,
                         fillColor.r,
@@ -89,10 +95,7 @@ public class AGGRenderer: Renderer{
                         agg_object)
     }
 
-    public func drawSolidRectWithBorder(topLeftPoint p1: Point,
-                                        topRightPoint p2: Point,
-                                        bottomRightPoint p3: Point,
-                                        bottomLeftPoint p4: Point,
+    public func drawSolidRectWithBorder(_ rect: Rect,
                                         strokeWidth thickness: Float,
                                         fillColor: Color = Color.white,
                                         borderColor: Color = Color.black,
@@ -100,14 +103,15 @@ public class AGGRenderer: Renderer{
         var x = [Float]()
         var y = [Float]()
 
-        x.append(p1.x + xOffset)
-        x.append(p2.x + xOffset)
-        x.append(p3.x + xOffset)
-        x.append(p4.x + xOffset)
-        y.append(p1.y + yOffset)
-        y.append(p2.y + yOffset)
-        y.append(p3.y + yOffset)
-        y.append(p4.y + yOffset)
+        let pts = getPoints(from: rect)
+        x.append(pts.tL.x + xOffset)
+        x.append(pts.tR.x + xOffset)
+        x.append(pts.bR.x + xOffset)
+        x.append(pts.bL.x + xOffset)
+        y.append(pts.tL.y + yOffset)
+        y.append(pts.tR.y + yOffset)
+        y.append(pts.bR.y + yOffset)
+        y.append(pts.bL.y + yOffset)
 
         draw_solid_rect(x,
                         y,

--- a/Sources/QuartzRenderer/QuartzRenderer.swift
+++ b/Sources/QuartzRenderer/QuartzRenderer.swift
@@ -55,69 +55,45 @@ public class QuartzRenderer: Renderer {
         context.fill(rect)
     }
 
-    public func drawRect(topLeftPoint p1: Point,
-                         topRightPoint p2: Point,
-                         bottomRightPoint p3: Point,
-                         bottomLeftPoint p4: Point,
+    public func drawRect(_ rect: Rect,
                          strokeWidth thickness: Float,
                          strokeColor: Color = Color.black,
                          isOriginShifted: Bool) {
-        let w = abs(p2.x - p1.x)
-        let h = abs(p2.y - p3.y)
-        var y = min(p1.y,p2.y,p3.y,p4.y) + yOffset
-        var x = p1.x + xOffset
+        var rect = rect.normalized
+        rect.origin.x += xOffset
+        rect.origin.y += yOffset
         if (isOriginShifted) {
-            y = y + (0.1*plotDimensions.subHeight)
-            x = x + (0.1*plotDimensions.subWidth)
+            rect.origin.y += (0.1*plotDimensions.subHeight)
+            rect.origin.x += (0.1*plotDimensions.subWidth)
         }
-        let rect = CGRect(x: Double(x),
-                          y: Double(y),
-                          width: Double(w),
-                          height: Double(h))
         context.setStrokeColor(strokeColor.cgColor)
         context.setLineWidth(CGFloat(thickness))
-        context.stroke(rect)
+        context.stroke(CGRect(rect))
     }
 
-    public func drawSolidRect(topLeftPoint p1: Point,
-                              topRightPoint p2: Point,
-                              bottomRightPoint p3: Point,
-                              bottomLeftPoint p4: Point,
+    public func drawSolidRect(_ rect: Rect,
                               fillColor: Color = Color.white,
                               hatchPattern: BarGraphSeriesOptions.Hatching,
                               isOriginShifted: Bool) {
+        var rect = rect.normalized
         if (isOriginShifted) {
-            let w = abs(p2.x - p1.x)
-            let h = abs(p2.y - p3.y)
-            let y = min(p1.y,p2.y,p3.y,p4.y) + (0.1*plotDimensions.subHeight) + yOffset
-            let x = min(p1.x, p2.x, p3.x, p4.x) + xOffset + (0.1*plotDimensions.subWidth)
-            let rect = CGRect(x: Double(x),
-                              y: Double(y),
-                              width: Double(w),
-                              height: Double(h))
+            rect.origin.y += (0.1*plotDimensions.subHeight) + yOffset
+            rect.origin.x += (0.1*plotDimensions.subWidth) + xOffset
             context.setFillColor(fillColor.cgColor)
-            context.fill(rect)
-            drawHatchingRect(x: x, y: y, width: w, height: h, hatchPattern: hatchPattern)
+            context.fill(CGRect(rect))
+            drawHatchingRect(rect, hatchPattern: hatchPattern)
         }
         else {
-            let w: Float = abs(p2.x - p1.x)
-            let h: Float = abs(p2.y - p3.y)
-            let y = min(p1.y,p2.y,p3.y,p4.y) + yOffset
-            let x = p1.x + xOffset
-            let rect = CGRect(x: Double(x),
-                              y: Double(y),
-                              width: Double(w),
-                              height: Double(h))
+            rect.origin.y += yOffset
+            rect.origin.x += xOffset
             context.setFillColor(fillColor.cgColor)
-            context.fill(rect)
-            drawHatchingRect(x: x, y: y, width: w, height: h, hatchPattern: hatchPattern)
+            context.fill(CGRect(rect))
+            drawHatchingRect(rect, hatchPattern: hatchPattern)
         }
     }
     
-    func drawHatchingRect(x: Float,
-                          y: Float,
-                          width w: Float,
-                          height h: Float,
+    // Note: we assume this rect has already been offset-shifted.
+    func drawHatchingRect(_ rect: Rect,
                           hatchPattern: BarGraphSeriesOptions.Hatching) {
         switch (hatchPattern) {
         case .none:
@@ -147,10 +123,7 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
         case .backwardSlash:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
                 let line = CGMutablePath()
@@ -176,10 +149,7 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
 
         case .hollowCircle:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
@@ -206,10 +176,8 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
+            
         case .filledCircle:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
                 context.addArc(
@@ -234,10 +202,7 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
 
         case .vertical:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
@@ -264,10 +229,8 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
+            
         case .horizontal:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
                 let line = CGMutablePath()
@@ -293,10 +256,8 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
+            
         case .grid:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
                 let line = CGMutablePath()
@@ -324,10 +285,8 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
+            
         case .cross:
             let drawPattern: CGPatternDrawPatternCallback = { _, context in
                 let line = CGMutablePath()
@@ -355,39 +314,28 @@ public class QuartzRenderer: Renderer {
             context.setFillColorSpace(patternSpace)
             var alpha : CGFloat = 1.0
             context.setFillPattern(pattern!, colorComponents: &alpha)
-            context.fill(CGRect(x: Double(x + xOffset),
-                                y: Double(y + yOffset),
-                                width: Double(w),
-                                height: Double(h)))
+            context.fill(CGRect(rect))
         }
     }
 
-    public func drawSolidRectWithBorder(topLeftPoint p1: Point,
-                                        topRightPoint p2: Point,
-                                        bottomRightPoint p3: Point,
-                                        bottomLeftPoint p4: Point,
+    public func drawSolidRectWithBorder(_ rect: Rect,
                                         strokeWidth thickness: Float,
                                         fillColor: Color = Color.white,
                                         borderColor: Color = Color.black,
                                         isOriginShifted: Bool) {
-        let w: Float = abs(p2.x - p1.x)
-        let h: Float = abs(p2.y - p3.y)
-        var y = min(p1.y,p2.y,p3.y,p4.y) + yOffset
-        var x = p1.x + xOffset
+        var rect = rect.normalized
+        rect.origin.x += xOffset
+        rect.origin.y += yOffset
         if (isOriginShifted) {
-            y = y + (0.1*plotDimensions.subHeight)
-            x = x + (0.1*plotDimensions.subWidth)
+            rect.origin.y += (0.1*plotDimensions.subHeight)
+            rect.origin.x += (0.1*plotDimensions.subWidth)
         }
 
-        let rect = CGRect(x: Double(x),
-                          y: Double(y),
-                          width: Double(w),
-                          height: Double(h))
         context.setFillColor(fillColor.cgColor)
-        context.fill(rect)
+        context.fill(CGRect(rect))
         context.setStrokeColor(borderColor.cgColor)
         context.setLineWidth(CGFloat(thickness))
-        context.stroke(rect)
+        context.stroke(CGRect(rect))
     }
 
     public func drawSolidCircle(center c: Point,
@@ -569,6 +517,26 @@ public class QuartzRenderer: Renderer {
             image.writePng(to: destinationURL)
             #endif
         }
+    }
+}
+
+// - Helpers
+
+extension CGPoint {
+    init(_ swiftplotPoint: SwiftPlot.Point) {
+        self.init(x: CGFloat(swiftplotPoint.x), y: CGFloat(swiftplotPoint.y))
+    }
+}
+
+extension CGSize {
+    init(_ swiftplotSize: SwiftPlot.Size) {
+        self.init(width: CGFloat(swiftplotSize.width), height: CGFloat(swiftplotSize.height))
+    }
+}
+
+extension CGRect {
+    init(_ swiftplotRect: SwiftPlot.Rect) {
+        self.init(origin: CGPoint(swiftplotRect.origin), size: CGSize(swiftplotRect.size))
     }
 }
 

--- a/Sources/SVGRenderer/SVGRenderer.swift
+++ b/Sources/SVGRenderer/SVGRenderer.swift
@@ -48,151 +48,125 @@ public class SVGRenderer: Renderer{
         image = image + "\n" + font
         LCARS_CHAR_SIZE_ARRAY = [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 17, 26, 46, 63, 42, 105, 45, 20, 25, 25, 47, 39, 21, 34, 26, 36, 36, 28, 36, 36, 36, 36, 36, 36, 36, 36, 27, 27, 36, 35, 36, 35, 65, 42, 43, 42, 44, 35, 34, 43, 46, 25, 39, 40, 31, 59, 47, 43, 41, 43, 44, 39, 28, 44, 43, 65, 37, 39, 34, 37, 42, 37, 50, 37, 32, 43, 43, 39, 43, 40, 30, 42, 45, 23, 25, 39, 23, 67, 45, 41, 43, 42, 30, 40, 28, 45, 33, 52, 33, 36, 31, 39, 26, 39, 55]
     }
+    
+    func convertToSVGCoordinates(_ rect: Rect) -> Rect {
+        // Convert to SVG coordinate system (0,0 at top-left).
+        var rect = rect.normalized
+        rect.origin = Point(rect.origin.x + xOffset, rect.maxY - yOffset)
+        return rect
+    }
 
-    public func drawRect(topLeftPoint p1: Point,
-                         topRightPoint p2: Point,
-                         bottomRightPoint p3: Point,
-                         bottomLeftPoint p4: Point,
+    public func drawRect(_ rect: Rect,
                          strokeWidth thickness: Float,
                          strokeColor: Color = Color.black,
                          isOriginShifted: Bool) {
-        let w = abs(p2.x - p1.x)
-        let h = abs(p2.y - p3.y)
-        var y = max(p1.y,p2.y,p3.y,p4.y) - yOffset
-        var x = p1.x + xOffset
+        var rect = convertToSVGCoordinates(rect)
         if (isOriginShifted) {
-            y = y + (0.1*plotDimensions.subHeight)
-            y = plotDimensions.subHeight - y
-            x = x + (0.1*plotDimensions.subWidth)
+            rect.origin.y += (0.1*plotDimensions.subHeight)
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
+            rect.origin.x += (0.1*plotDimensions.subWidth)
         }
         else {
-            y = plotDimensions.subHeight - y
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
         }
-        let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:rgb(255,255,255);stroke-width:\(thickness);stroke:rgb(0,0,0);opacity:1;fill-opacity:0;\" />"
-        image = image + "\n" + rect
+        let rectStr = "<rect x=\"\(rect.origin.x)\" y=\"\(rect.origin.y)\" width=\"\(rect.size.width)\" height=\"\(rect.size.height)\" style=\"fill:rgb(255,255,255);stroke-width:\(thickness);stroke:rgb(0,0,0);opacity:1;fill-opacity:0;\" />"
+        image = image + "\n" + rectStr
     }
 
-    public func drawSolidRect(topLeftPoint p1: Point,
-                              topRightPoint p2: Point,
-                              bottomRightPoint p3: Point,
-                              bottomLeftPoint p4: Point,
+    public func drawSolidRect(_ rect: Rect,
                               fillColor: Color = Color.white,
                               hatchPattern: BarGraphSeriesOptions.Hatching,
                               isOriginShifted: Bool) {
+        var rect = convertToSVGCoordinates(rect)
         if (isOriginShifted) {
-            let w = abs(p2.x - p1.x)
-            let h = abs(p2.y - p3.y)
-            var y = max(p1.y,p2.y,p3.y,p4.y) + (0.1*plotDimensions.subHeight) - yOffset
-            y = plotDimensions.subHeight - y
-            let x = min(p1.x, p2.x, p3.x, p4.x) + xOffset + (0.1*plotDimensions.subWidth)
-            let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:rgb(\(fillColor.r*255.0),\(fillColor.g*255.0),\(fillColor.b*255.0));stroke-width:0;stroke:rgb(0,0,0);opacity:\(fillColor.a)\" />"
-            image = image + "\n" + rect
-            drawHatchingRect(x: x, y: y, width: w, height: h, hatchPattern: hatchPattern)
+            rect.origin.y += (0.1*plotDimensions.subHeight) - yOffset
+            rect.origin.x += xOffset + (0.1*plotDimensions.subWidth)
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
         }
         else {
-            let w: Float = abs(p2.x - p1.x)
-            let h: Float = abs(p2.y - p3.y)
-            var y = max(p1.y,p2.y,p3.y,p4.y) - yOffset
-            y = plotDimensions.subHeight - y
-            let x = p1.x + xOffset
-            let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:rgb(\(fillColor.r*255.0),\(fillColor.g*255.0),\(fillColor.b*255.0));stroke-width:0;stroke:rgb(0,0,0);opacity:\(fillColor.a)\" />"
-            image = image + "\n" + rect
-            drawHatchingRect(x: x, y: y, width: w, height: h, hatchPattern: hatchPattern)
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
         }
+        let rectStr = "<rect x=\"\(rect.origin.x)\" y=\"\(rect.origin.y)\" width=\"\(rect.size.width)\" height=\"\(rect.size.height)\" style=\"fill:rgb(\(fillColor.r*255.0),\(fillColor.g*255.0),\(fillColor.b*255.0));stroke-width:0;stroke:rgb(0,0,0);opacity:\(fillColor.a)\" />"
+        image = image + "\n" + rectStr
+        drawHatchingRect(rect, hatchPattern: hatchPattern)
     }
 
-    func drawHatchingRect(x: Float,
-                          y: Float,
-                          width w: Float,
-                          height h: Float,
+    func drawHatchingRect(_ rect: Rect,
                           hatchPattern: BarGraphSeriesOptions.Hatching) {
-        switch (hatchPattern.rawValue) {
-        case 0:
-            break
-        case 1:
+        let patternName: String
+        switch (hatchPattern) {
+        case .none:
+            return
+        case .forwardSlash:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + forwardSlashHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#forwardSlashHatch);opacity:\(1)\" />"
-            image = image + rect
-        case 2:
+            patternName = "url(#forwardSlashHatch)"
+        case .backwardSlash:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + backwardSlashHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#backwardSlashHatch);opacity:\(1)\" />"
-            image = image + rect
-        case 3:
+            patternName = "url(#backwardSlashHatch)"
+        case .hollowCircle:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + hollowCircleHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let hollowCircle: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#hollowCircleHatch);opacity:\(1)\" />"
-            image = image + hollowCircle
-        case 4:
+            patternName = "url(#hollowCircleHatch)"
+        case .filledCircle:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + filledCircleHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let filledCircle: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#filledCircleHatch);opacity:\(1)\" />"
-            image = image + filledCircle
-        case 5:
+            patternName = "url(#filledCircleHatch)"
+        case .vertical:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + verticalHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let verticalLine: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#verticalHatch);opacity:\(1)\" />"
-            image = image + verticalLine
-        case 6:
+            patternName = "url(#verticalHatch)"
+        case .horizontal:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + horizontalHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let horizontalLine: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#horizontalHatch);opacity:\(1)\" />"
-            image = image + horizontalLine
-        case 7:
+            patternName = "url(#horizontalHatch)"
+        case .grid:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + gridHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let grid: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#gridHatch);opacity:\(1)\" />"
-            image = image + grid
-        case 8:
+            patternName = "url(#gridHatch)"
+        case .cross:
             if (!hatchingIncluded[hatchPattern.rawValue]) {
                 image = image + crossHatch;
                 hatchingIncluded[hatchPattern.rawValue] = true
             }
-            let cross: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:url(#crossHatch);opacity:\(1)\" />"
-            image = image + cross
-        default:
-            break
+            patternName = "url(#crossHatch)"
         }
+        let rectStr = "<rect x=\"\(rect.origin.x)\" y=\"\(rect.origin.y)\" width=\"\(rect.size.width)\" height=\"\(rect.size.height)\" style=\"fill:\(patternName);opacity:\(1)\" />"
+        image = image + rectStr
     }
 
-    public func drawSolidRectWithBorder(topLeftPoint p1: Point,
-                                        topRightPoint p2: Point,
-                                        bottomRightPoint p3: Point,
-                                        bottomLeftPoint p4: Point,
+    public func drawSolidRectWithBorder(_ rect: Rect,
                                         strokeWidth thickness: Float,
                                         fillColor: Color = Color.white,
                                         borderColor: Color = Color.black,
                                         isOriginShifted: Bool) {
-        let w: Float = abs(p2.x - p1.x)
-        let h: Float = abs(p2.y - p3.y)
-        var y = max(p1.y,p2.y,p3.y,p4.y) - yOffset
-        var x = p1.x + xOffset
+        var rect = convertToSVGCoordinates(rect)
         if (isOriginShifted) {
-            y = y + (0.1*plotDimensions.subHeight)
-            y = plotDimensions.subHeight - y
-            x = x + (0.1*plotDimensions.subWidth)
+            rect.origin.y += (0.1*plotDimensions.subHeight)
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
+            rect.origin.x += (0.1*plotDimensions.subWidth)
         }
         else {
-            y = plotDimensions.subHeight - y
+            rect.origin.y = plotDimensions.subHeight - rect.origin.y
         }
 
-        let rect: String = "<rect x=\"\(x)\" y=\"\(y)\" width=\"\(w)\" height=\"\(h)\" style=\"fill:rgb(\(fillColor.r*255.0),\(fillColor.g*255.0),\(fillColor.b*255.0));stroke-width:\(thickness);stroke:rgb(\(borderColor.r*255.0),\(borderColor.g*255.0),\(borderColor.b*255.0));opacity:\(fillColor.a)\" />"
-        image = image + "\n" + rect
+        let rectStr = "<rect x=\"\(rect.origin.x)\" y=\"\(rect.origin.y)\" width=\"\(rect.size.width)\" height=\"\(rect.size.height)\" style=\"fill:rgb(\(fillColor.r*255.0),\(fillColor.g*255.0),\(fillColor.b*255.0));stroke-width:\(thickness);stroke:rgb(\(borderColor.r*255.0),\(borderColor.g*255.0),\(borderColor.b*255.0));opacity:\(fillColor.a)\" />"
+        image = image + "\n" + rectStr
     }
 
     public func drawSolidCircle(center c: Point,

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -14,9 +14,7 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
         didSet {
-            Self.updatePlot(legend: &plotLegend,
-                            border: &plotBorder,
-                            fromDimensions: plotDimensions)
+            calcBorderAndLegend()
         }
     }
     public enum GraphOrientation {
@@ -38,17 +36,6 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     var barWidth : Int = 0
     var origin = zeroPoint
 
-    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
-        border.rect.origin.x = dimensions.subWidth*0.1
-        border.rect.origin.y = dimensions.subHeight*0.9
-        border.rect.size.width = dimensions.subWidth*0.8
-        border.rect.size.height = dimensions.subHeight * -0.8
-        border.rect = border.rect.normalized
-        
-        legend.legendTopLeft = Point(border.rect.minX + Float(20),
-                                     border.rect.maxY - Float(20))
-    }
-    
     public init(width: Float = 1000,
                 height: Float = 660,
                 enableGrid: Bool = false){
@@ -119,9 +106,7 @@ extension BarGraph {
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -137,9 +122,7 @@ extension BarGraph {
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -181,6 +164,17 @@ extension BarGraph {
             plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
           )
         }
+    }
+    
+    func calcBorderAndLegend() {
+        plotBorder.rect.origin.x = plotDimensions.subWidth*0.1
+        plotBorder.rect.origin.y = plotDimensions.subHeight*0.9
+        plotBorder.rect.size.width = plotDimensions.subWidth*0.8
+        plotBorder.rect.size.height = plotDimensions.subHeight * -0.8
+        plotBorder.rect = plotBorder.rect.normalized
+        
+        plotLegend.legendTopLeft = Point(plotBorder.rect.minX + Float(20),
+                                         plotBorder.rect.maxY - Float(20))
     }
 
     func calcMarkerLocAndScalePts(renderer: Renderer){

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -14,9 +14,7 @@ public class Histogram<T:FloatConvertible>: Plot {
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
         didSet {
-            Self.updatePlot(legend: &plotLegend,
-                            border: &plotBorder,
-                            fromDimensions: plotDimensions)
+            calcBorderAndLegend()
         }
     }
     public var strokeWidth: Float = 2
@@ -34,17 +32,6 @@ public class Histogram<T:FloatConvertible>: Plot {
     var xMargin: Float = 5
     var isNormalized = false
     var origin = zeroPoint
-    
-    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
-        border.rect.origin.x = dimensions.subWidth*0.1
-        border.rect.origin.y = dimensions.subHeight*0.9
-        border.rect.size.width = dimensions.subWidth*0.8
-        border.rect.size.height = dimensions.subHeight * -0.8
-        border.rect = border.rect.normalized
-
-        legend.legendTopLeft = Point(border.rect.minX + Float(20),
-                                     border.rect.maxY - Float(20))
-    }
 
     public init(width: Float = 1000,
                 height: Float = 660,
@@ -161,9 +148,7 @@ extension Histogram {
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -179,9 +164,7 @@ extension Histogram {
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -222,6 +205,17 @@ extension Histogram {
               plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
             )
         }
+    }
+    
+    func calcBorderAndLegend() {
+        plotBorder.rect.origin.x = plotDimensions.subWidth*0.1
+        plotBorder.rect.origin.y = plotDimensions.subHeight*0.9
+        plotBorder.rect.size.width = plotDimensions.subWidth*0.8
+        plotBorder.rect.size.height = plotDimensions.subHeight * -0.8
+        plotBorder.rect = plotBorder.rect.normalized
+        
+        plotLegend.legendTopLeft = Point(plotBorder.rect.minX + Float(20),
+                                         plotBorder.rect.maxY - Float(20))
     }
 
     func calcMarkerLocAndScalePts(renderer: Renderer){

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -13,17 +13,10 @@ public class LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
     public var plotLegend: PlotLegend = PlotLegend()
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
-        willSet{
-            plotBorder.topLeft       = Point(newValue.subWidth*0.1,
-                                             newValue.subHeight*0.9)
-            plotBorder.topRight      = Point(newValue.subWidth*0.9,
-                                             newValue.subHeight*0.9)
-            plotBorder.bottomLeft    = Point(newValue.subWidth*0.1,
-                                             newValue.subHeight*0.1)
-            plotBorder.bottomRight   = Point(newValue.subWidth*0.9,
-                                             newValue.subHeight*0.1)
-            plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                             plotBorder.topLeft.y - Float(20))
+        didSet {
+            Self.updatePlot(legend: &plotLegend,
+                            border: &plotBorder,
+                            fromDimensions: plotDimensions)
         }
     }
     public var plotLineThickness: Float = 1.5
@@ -35,6 +28,17 @@ public class LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
 
     var primaryAxis = Axis<T,U>()
     var secondaryAxis: Axis<T,U>? = nil
+    
+    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
+        border.rect.origin.x = dimensions.subWidth*0.1
+        border.rect.origin.y = dimensions.subHeight*0.9
+        border.rect.size.width = dimensions.subWidth*0.8
+        border.rect.size.height = dimensions.subHeight * -0.8
+        border.rect = border.rect.normalized
+        
+        legend.legendTopLeft = Point(border.rect.minX + Float(20),
+                                     border.rect.maxY - Float(20))
+    }
 
     public init(points : [Pair<T,U>],
                 width: Float = 1000,
@@ -138,16 +142,9 @@ extension LineGraph{
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        plotBorder.topLeft       = Point(plotDimensions.subWidth*0.1,
-                                        plotDimensions.subHeight*0.9)
-        plotBorder.topRight      = Point(plotDimensions.subWidth*0.9,
-                                        plotDimensions.subHeight*0.9)
-        plotBorder.bottomLeft    = Point(plotDimensions.subWidth*0.1,
-                                        plotDimensions.subHeight*0.1)
-        plotBorder.bottomRight   = Point(plotDimensions.subWidth*0.9,
-                                        plotDimensions.subHeight*0.1)
-        plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                         plotBorder.topLeft.y - Float(20))
+        Self.updatePlot(legend: &plotLegend,
+                        border: &plotBorder,
+                        fromDimensions: plotDimensions)
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -163,16 +160,9 @@ extension LineGraph{
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        plotBorder.topLeft       = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.topRight      = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.bottomLeft    = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.1)
-        plotBorder.bottomRight   = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.1)
-        plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                         plotBorder.topLeft.y - Float(20))
+        Self.updatePlot(legend: &plotLegend,
+                        border: &plotBorder,
+                        fromDimensions: plotDimensions)
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -196,16 +186,22 @@ extension LineGraph{
                                                          textSize: plotLabel!.labelSize)
             let yWidth    : Float = renderer.getTextWidth(text: plotLabel!.yLabel,
                                                           textSize: plotLabel!.labelSize)
-            plotLabel!.xLabelLocation = Point(((plotBorder.bottomRight.x + plotBorder.bottomLeft.x)*Float(0.5)) - xWidth*Float(0.5),
-                                                                                plotBorder.bottomLeft.y - plotLabel!.labelSize - 0.05*plotDimensions.graphHeight)
-            plotLabel!.yLabelLocation = Point((plotBorder.bottomLeft.x - plotLabel!.labelSize - 0.05*plotDimensions.graphWidth),
-                                                                               ((plotBorder.bottomLeft.y + plotBorder.topLeft.y)*Float(0.5) - yWidth))
+            plotLabel!.xLabelLocation = Point(
+                plotBorder.rect.midX - xWidth * 0.5,
+                plotBorder.rect.minY - plotLabel!.labelSize - 0.05 * plotDimensions.graphHeight
+            )
+            plotLabel!.yLabelLocation = Point(
+                plotBorder.rect.origin.x - plotLabel!.labelSize - 0.05 * plotDimensions.graphWidth,
+                plotBorder.rect.midY - yWidth
+            )
         }
         if (plotTitle != nil) {
-          let titleWidth: Float = renderer.getTextWidth(text: plotTitle!.title,
-                                                        textSize: plotTitle!.titleSize)
-          plotTitle!.titleLocation = Point(((plotBorder.topRight.x + plotBorder.topLeft.x)*Float(0.5)) - titleWidth*Float(0.5),
-                                                                               plotBorder.topLeft.y + plotTitle!.titleSize*Float(0.5))
+            let titleWidth: Float = renderer.getTextWidth(text: plotTitle!.title,
+                                                          textSize: plotTitle!.titleSize)
+            plotTitle!.titleLocation = Point(
+                plotBorder.rect.midX - titleWidth * 0.5,
+                plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
+            )
         }
     }
 
@@ -554,10 +550,7 @@ extension LineGraph{
 
     //functions to draw the plot
     func drawBorder(renderer: Renderer){
-        renderer.drawRect(topLeftPoint: plotBorder.topLeft,
-                          topRightPoint: plotBorder.topRight,
-                          bottomRightPoint: plotBorder.bottomRight,
-                          bottomLeftPoint: plotBorder.bottomLeft,
+        renderer.drawRect(plotBorder.rect,
                           strokeWidth: plotBorder.borderThickness,
                           strokeColor: Color.black,
                           isOriginShifted: false)
@@ -728,40 +721,27 @@ extension LineGraph{
         plotLegend.legendWidth  = maxWidth + 3.5*plotLegend.legendTextSize
         plotLegend.legendHeight = (Float(allSeries.count)*2.0 + 1.0)*plotLegend.legendTextSize
 
-        let p1 = Point(plotLegend.legendTopLeft.x,
-                       plotLegend.legendTopLeft.y)
-        let p2 = Point(plotLegend.legendTopLeft.x + plotLegend.legendWidth,
-                       plotLegend.legendTopLeft.y)
-        let p3 = Point(plotLegend.legendTopLeft.x + plotLegend.legendWidth,
-                       plotLegend.legendTopLeft.y - plotLegend.legendHeight)
-        let p4 = Point(plotLegend.legendTopLeft.x,
-                       plotLegend.legendTopLeft.y - plotLegend.legendHeight)
-
-        renderer.drawSolidRectWithBorder(topLeftPoint: p1,
-                                         topRightPoint: p2,
-                                         bottomRightPoint: p3,
-                                         bottomLeftPoint: p4,
+        let legendRect = Rect(
+            origin: plotLegend.legendTopLeft,
+            size: Size(width: plotLegend.legendWidth, height: -plotLegend.legendHeight)
+        ).normalized
+        renderer.drawSolidRectWithBorder(legendRect,
                                          strokeWidth: plotBorder.borderThickness,
                                          fillColor: Color.transluscentWhite,
                                          borderColor: Color.black,
                                          isOriginShifted: false)
 
         for i in 0..<allSeries.count {
-            let tL = Point(plotLegend.legendTopLeft.x + plotLegend.legendTextSize,
-                           plotLegend.legendTopLeft.y - (2.0*Float(i) + 1.0)*plotLegend.legendTextSize)
-            let bR = Point(tL.x + plotLegend.legendTextSize,
-                           tL.y - plotLegend.legendTextSize)
-            let tR = Point(bR.x, tL.y)
-            let bL = Point(tL.x, bR.y)
-            renderer.drawSolidRect(topLeftPoint: tL,
-                                   topRightPoint: tR,
-                                   bottomRightPoint: bR,
-                                   bottomLeftPoint: bL,
+            let seriesIcon = Rect(
+                origin: Point(legendRect.origin.x + plotLegend.legendTextSize,
+                              legendRect.maxY - (2.0*Float(i) + 1.0)*plotLegend.legendTextSize),
+                size: Size(width: plotLegend.legendTextSize, height: -plotLegend.legendTextSize)
+            )
+            renderer.drawSolidRect(seriesIcon,
                                    fillColor: allSeries[i].color,
                                    hatchPattern: .none,
                                    isOriginShifted: false)
-            let p = Point(bR.x + plotLegend.legendTextSize,
-                          bR.y)
+            let p = Point(seriesIcon.maxX + plotLegend.legendTextSize, seriesIcon.minY)
             renderer.drawText(text: allSeries[i].label,
                               location: p,
                               textSize: plotLegend.legendTextSize,

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -14,9 +14,7 @@ public class LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
         didSet {
-            Self.updatePlot(legend: &plotLegend,
-                            border: &plotBorder,
-                            fromDimensions: plotDimensions)
+            calcBorderAndLegend()
         }
     }
     public var plotLineThickness: Float = 1.5
@@ -28,17 +26,6 @@ public class LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
 
     var primaryAxis = Axis<T,U>()
     var secondaryAxis: Axis<T,U>? = nil
-    
-    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
-        border.rect.origin.x = dimensions.subWidth*0.1
-        border.rect.origin.y = dimensions.subHeight*0.9
-        border.rect.size.width = dimensions.subWidth*0.8
-        border.rect.size.height = dimensions.subHeight * -0.8
-        border.rect = border.rect.normalized
-        
-        legend.legendTopLeft = Point(border.rect.minX + Float(20),
-                                     border.rect.maxY - Float(20))
-    }
 
     public init(points : [Pair<T,U>],
                 width: Float = 1000,
@@ -142,9 +129,7 @@ extension LineGraph{
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -160,9 +145,7 @@ extension LineGraph{
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -203,6 +186,17 @@ extension LineGraph{
                 plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
             )
         }
+    }
+    
+    func calcBorderAndLegend() {
+        plotBorder.rect.origin.x = plotDimensions.subWidth*0.1
+        plotBorder.rect.origin.y = plotDimensions.subHeight*0.9
+        plotBorder.rect.size.width = plotDimensions.subWidth*0.8
+        plotBorder.rect.size.height = plotDimensions.subHeight * -0.8
+        plotBorder.rect = plotBorder.rect.normalized
+        
+        plotLegend.legendTopLeft = Point(plotBorder.rect.minX + Float(20),
+                                         plotBorder.rect.maxY - Float(20))
     }
 
     func calcMarkerLocAndScalePts(renderer: Renderer){

--- a/Sources/SwiftPlot/Pair.swift
+++ b/Sources/SwiftPlot/Pair.swift
@@ -15,9 +15,68 @@ public let zeroPoint = Point(0.0, 0.0)
 public struct Size {
     public var width: Float
     public var height: Float
+    
+    public init(width: Float, height: Float) {
+        self.width = width
+        self.height = height
+    }
+}
+extension Size {
+    public static let zero = Size(width: 0, height: 0)
 }
 
+/// A Rectangle in a bottom-left coordinate space.
+///
 public struct Rect {
     public var origin: Point
     public var size: Size
+    
+    public init(origin: Point, size: Size) {
+        self.origin = origin
+        self.size = size
+    }
+}
+extension Rect {
+    
+    public static let empty = Rect(origin: zeroPoint, size: .zero)
+    
+    public var normalized: Rect {
+        let normalizedOrigin = Point(origin.x + (size.width < 0 ? size.width : 0),
+                                     origin.y + (size.height < 0 ? size.height : 0))
+        let normalizedSize = Size(width: abs(size.width), height: abs(size.height))
+        return Rect(origin: normalizedOrigin, size: normalizedSize)
+    }
+    
+    public var minX: Float {
+        return normalized.origin.x
+    }
+    
+    public var minY: Float {
+        return normalized.origin.y
+    }
+    
+    public var midX: Float {
+        return origin.x + (size.width/2)
+    }
+    
+    public var midY: Float {
+        return origin.y + (size.height/2)
+    }
+
+    public var maxX: Float {
+        let norm = normalized
+        return norm.origin.x + norm.size.width
+    }
+    
+    public var maxY: Float {
+        let norm = normalized
+        return norm.origin.y + norm.size.height
+    }
+    
+    public init(size: Size, centeredOn center: Point) {
+        self = Rect(
+            origin: Point(center.x - size.width/2, center.y - size.height/2),
+            size: size
+        )
+    }
 }

--- a/Sources/SwiftPlot/Pair.swift
+++ b/Sources/SwiftPlot/Pair.swift
@@ -1,7 +1,7 @@
 // struct defining a Pair
 public struct Pair<T,U> {
-    public let x: T
-    public let y: U
+    public var x: T
+    public var y: U
 
     public init(_ x: T, _ y: U){
         self.x = x
@@ -11,3 +11,13 @@ public struct Pair<T,U> {
 
 public typealias Point = Pair<Float,Float>
 public let zeroPoint = Point(0.0, 0.0)
+
+public struct Size {
+    public var width: Float
+    public var height: Float
+}
+
+public struct Rect {
+    public var origin: Point
+    public var size: Size
+}

--- a/Sources/SwiftPlot/PlotBorder.swift
+++ b/Sources/SwiftPlot/PlotBorder.swift
@@ -1,8 +1,5 @@
 public struct PlotBorder{
-    public var topLeft = zeroPoint
-    public var topRight = zeroPoint
-    public var bottomLeft = zeroPoint
-    public var bottomRight = zeroPoint
+    public var rect: Rect = .empty
     public var borderThickness: Float = 2
     public init() {}
 }

--- a/Sources/SwiftPlot/Renderer.swift
+++ b/Sources/SwiftPlot/Renderer.swift
@@ -33,10 +33,7 @@ public protocol Renderer: AnyObject{
     *             without shifted origin. This is decided by the boolean
     *             parameter 'isOriginShifted'.
     */
-    func drawRect(topLeftPoint p1: Point,
-                  topRightPoint p2: Point,
-                  bottomRightPoint p3: Point,
-                  bottomLeftPoint p4: Point,
+    func drawRect(_ rect: Rect,
                   strokeWidth thickness: Float,
                   strokeColor: Color,
                   isOriginShifted: Bool)
@@ -54,10 +51,7 @@ public protocol Renderer: AnyObject{
     *             without shifted origin.
     *             This is decided by the boolean parameter 'isOriginShifted'.
     */
-    func drawSolidRect(topLeftPoint p1: Point,
-                       topRightPoint p2: Point,
-                       bottomRightPoint p3: Point,
-                       bottomLeftPoint p4: Point,
+    func drawSolidRect(_ rect: Rect,
                        fillColor: Color,
                        hatchPattern: BarGraphSeriesOptions.Hatching,
                        isOriginShifted: Bool)
@@ -125,10 +119,7 @@ public protocol Renderer: AnyObject{
     *             This function can operate in both coordinate systems with and without shifted origin.
     *             This is decided by the boolean parameter isOriginShifted.
     */
-    func drawSolidRectWithBorder(topLeftPoint p1: Point,
-                                 topRightPoint p2: Point,
-                                 bottomRightPoint p3: Point,
-                                 bottomLeftPoint p4: Point,
+    func drawSolidRectWithBorder(_ rect: Rect,
                                  strokeWidth thickness: Float, fillColor: Color,
                                  borderColor: Color,
                                  isOriginShifted: Bool)

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -16,9 +16,7 @@ public class ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
         didSet {
-            Self.updatePlot(legend: &plotLegend,
-                            border: &plotBorder,
-                            fromDimensions: plotDimensions)
+            calcBorderAndLegend()
         }
     }
     // public var plotLineThickness: Float = 3
@@ -32,17 +30,6 @@ public class ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
     var scaleY: Float = 1
     var plotMarkers: PlotMarkers = PlotMarkers()
     var series = [Series<T,U>]()
-    
-    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
-        border.rect.origin.x = dimensions.subWidth*0.1
-        border.rect.origin.y = dimensions.subHeight*0.9
-        border.rect.size.width = dimensions.subWidth*0.8
-        border.rect.size.height = dimensions.subHeight * -0.8
-        border.rect = border.rect.normalized
-        
-        legend.legendTopLeft = Point(border.rect.minX + Float(20),
-                                     border.rect.maxY - Float(20))
-    }
 
     public init(points p: [Pair<T,U>],
                 width: Float = 1000,
@@ -146,9 +133,7 @@ extension ScatterPlot{
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -164,9 +149,7 @@ extension ScatterPlot{
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        Self.updatePlot(legend: &plotLegend,
-                        border: &plotBorder,
-                        fromDimensions: plotDimensions)
+        calcBorderAndLegend()
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -206,6 +189,17 @@ extension ScatterPlot{
             plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
           )
         }
+    }
+    
+    func calcBorderAndLegend() {
+        plotBorder.rect.origin.x = plotDimensions.subWidth*0.1
+        plotBorder.rect.origin.y = plotDimensions.subHeight*0.9
+        plotBorder.rect.size.width = plotDimensions.subWidth*0.8
+        plotBorder.rect.size.height = plotDimensions.subHeight * -0.8
+        plotBorder.rect = plotBorder.rect.normalized
+        
+        plotLegend.legendTopLeft = Point(plotBorder.rect.minX + Float(20),
+                                         plotBorder.rect.maxY - Float(20))
     }
 
     func calcMarkerLocAndScalePts(renderer: Renderer){

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -15,17 +15,10 @@ public class ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
     public var plotLegend: PlotLegend = PlotLegend()
     public var plotBorder: PlotBorder = PlotBorder()
     public var plotDimensions: PlotDimensions {
-        willSet{
-            plotBorder.topLeft       = Point(newValue.subWidth*0.1,
-                                             newValue.subHeight*0.9)
-            plotBorder.topRight      = Point(newValue.subWidth*0.9,
-                                             newValue.subHeight*0.9)
-            plotBorder.bottomLeft    = Point(newValue.subWidth*0.1,
-                                             newValue.subHeight*0.1)
-            plotBorder.bottomRight   = Point(newValue.subWidth*0.9,
-                                             newValue.subHeight*0.1)
-            plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                             plotBorder.topLeft.y - Float(20))
+        didSet {
+            Self.updatePlot(legend: &plotLegend,
+                            border: &plotBorder,
+                            fromDimensions: plotDimensions)
         }
     }
     // public var plotLineThickness: Float = 3
@@ -39,6 +32,17 @@ public class ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
     var scaleY: Float = 1
     var plotMarkers: PlotMarkers = PlotMarkers()
     var series = [Series<T,U>]()
+    
+    static func updatePlot(legend: inout PlotLegend, border: inout PlotBorder, fromDimensions dimensions: PlotDimensions) {
+        border.rect.origin.x = dimensions.subWidth*0.1
+        border.rect.origin.y = dimensions.subHeight*0.9
+        border.rect.size.width = dimensions.subWidth*0.8
+        border.rect.size.height = dimensions.subHeight * -0.8
+        border.rect = border.rect.normalized
+        
+        legend.legendTopLeft = Point(border.rect.minX + Float(20),
+                                     border.rect.maxY - Float(20))
+    }
 
     public init(points p: [Pair<T,U>],
                 width: Float = 1000,
@@ -142,16 +146,9 @@ extension ScatterPlot{
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
         renderer.plotDimensions = plotDimensions
-        plotBorder.topLeft       = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.topRight      = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.bottomLeft    = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.1)
-        plotBorder.bottomRight   = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.1)
-        plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                         plotBorder.topLeft.y - Float(20))
+        Self.updatePlot(legend: &plotLegend,
+                        border: &plotBorder,
+                        fromDimensions: plotDimensions)
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -167,16 +164,9 @@ extension ScatterPlot{
     public func drawGraph(renderer: Renderer){
         renderer.xOffset = xOffset
         renderer.yOffset = yOffset
-        plotBorder.topLeft       = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.topRight      = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.9)
-        plotBorder.bottomLeft    = Point(plotDimensions.subWidth*0.1,
-                                         plotDimensions.subHeight*0.1)
-        plotBorder.bottomRight   = Point(plotDimensions.subWidth*0.9,
-                                         plotDimensions.subHeight*0.1)
-        plotLegend.legendTopLeft = Point(plotBorder.topLeft.x + Float(20),
-                                         plotBorder.topLeft.y - Float(20))
+        Self.updatePlot(legend: &plotLegend,
+                        border: &plotBorder,
+                        fromDimensions: plotDimensions)
         calcLabelLocations(renderer: renderer)
         calcMarkerLocAndScalePts(renderer: renderer)
         drawGrid(renderer: renderer)
@@ -200,15 +190,21 @@ extension ScatterPlot{
                                                       textSize: plotLabel!.labelSize)
             let yWidth: Float = renderer.getTextWidth(text: plotLabel!.yLabel,
                                                       textSize: plotLabel!.labelSize)
-            plotLabel!.xLabelLocation = Point(((plotBorder.bottomRight.x + plotBorder.bottomLeft.x)*Float(0.5)) - xWidth*Float(0.5),
-                                              plotBorder.bottomLeft.y - plotLabel!.labelSize - 0.05*plotDimensions.graphHeight)
-            plotLabel!.yLabelLocation = Point((plotBorder.bottomLeft.x - plotLabel!.labelSize - 0.05*plotDimensions.graphWidth),
-                                              ((plotBorder.bottomLeft.y + plotBorder.topLeft.y)*Float(0.5) - yWidth))
+            plotLabel!.xLabelLocation = Point(
+                plotBorder.rect.midX - xWidth * 0.5,
+                plotBorder.rect.minY - plotLabel!.labelSize - 0.05 * plotDimensions.graphHeight
+            )
+            plotLabel!.yLabelLocation = Point(
+                plotBorder.rect.origin.x - plotLabel!.labelSize - 0.05 * plotDimensions.graphWidth,
+                plotBorder.rect.midY - yWidth
+            )
         }
         if (plotTitle != nil) {
           let titleWidth: Float = renderer.getTextWidth(text: plotTitle!.title, textSize: plotTitle!.titleSize)
-          plotTitle!.titleLocation = Point(((plotBorder.topRight.x + plotBorder.topLeft.x)*Float(0.5)) - titleWidth*Float(0.5),
-                                           plotBorder.topLeft.y + plotTitle!.titleSize*Float(0.5))
+          plotTitle!.titleLocation = Point(
+            plotBorder.rect.midX - titleWidth * 0.5,
+            plotBorder.rect.maxY + plotTitle!.titleSize * 0.5
+          )
         }
     }
 
@@ -418,10 +414,7 @@ extension ScatterPlot{
 
     //functions to draw the plot
     func drawBorder(renderer: Renderer){
-        renderer.drawRect(topLeftPoint: plotBorder.topLeft,
-                          topRightPoint: plotBorder.topRight,
-                          bottomRightPoint: plotBorder.bottomRight,
-                          bottomLeftPoint: plotBorder.bottomLeft,
+        renderer.drawRect(plotBorder.rect,
                           strokeWidth: plotBorder.borderThickness,
                           strokeColor: Color.black,
                           isOriginShifted: false)
@@ -516,18 +509,9 @@ extension ScatterPlot{
                                          endColor: s.endColor!,
                                          Float(s.scaledValues[index].y-s.minY!)*seriesYRangeInverse)
                       }
-                      let tL = Point(p.x-scatterPatternSize*Float(0.5),
-                                     p.y+scatterPatternSize*Float(0.5))
-                      let tR = Point(p.x+scatterPatternSize*Float(0.5),
-                                     p.y+scatterPatternSize*Float(0.5))
-                      let bR = Point(p.x+scatterPatternSize*Float(0.5),
-                                     p.y-scatterPatternSize*Float(0.5))
-                      let bL = Point(p.x-scatterPatternSize*Float(0.5),
-                                     p.y-scatterPatternSize*Float(0.5))
-                      renderer.drawSolidRect(topLeftPoint: tL,
-                                             topRightPoint: tR,
-                                             bottomRightPoint: bR,
-                                             bottomLeftPoint: bL,
+                    let rect = Rect(size: Size(width: scatterPatternSize, height: scatterPatternSize),
+                                    centeredOn: p)
+                      renderer.drawSolidRect(rect,
                                              fillColor: s.color,
                                              hatchPattern: .none,
                                              isOriginShifted: true)
@@ -692,19 +676,11 @@ extension ScatterPlot{
         plotLegend.legendWidth  = maxWidth + 3.5*plotLegend.legendTextSize
         plotLegend.legendHeight = (Float(series.count)*2.0 + 1.0)*plotLegend.legendTextSize
 
-        let p1 = Point(plotLegend.legendTopLeft.x,
-                       plotLegend.legendTopLeft.y)
-        let p2 = Point(plotLegend.legendTopLeft.x + plotLegend.legendWidth,
-                       plotLegend.legendTopLeft.y)
-        let p3 = Point(plotLegend.legendTopLeft.x + plotLegend.legendWidth,
-                       plotLegend.legendTopLeft.y - plotLegend.legendHeight)
-        let p4 = Point(plotLegend.legendTopLeft.x,
-                       plotLegend.legendTopLeft.y - plotLegend.legendHeight)
-
-        renderer.drawSolidRectWithBorder(topLeftPoint: p1,
-                                         topRightPoint: p2,
-                                         bottomRightPoint: p3,
-                                         bottomLeftPoint: p4,
+        let legendRect = Rect(
+            origin: plotLegend.legendTopLeft,
+            size: Size(width: plotLegend.legendWidth, height: -plotLegend.legendHeight)
+        ).normalized
+        renderer.drawSolidRectWithBorder(legendRect,
                                          strokeWidth: plotBorder.borderThickness,
                                          fillColor: Color.transluscentWhite,
                                          borderColor: Color.black,
@@ -729,10 +705,11 @@ extension ScatterPlot{
                                              fillColor: series[i].color,
                                              isOriginShifted: false)
                 case .square:
-                    renderer.drawSolidRect(topLeftPoint: tL,
-                                           topRightPoint: tR,
-                                           bottomRightPoint: bR,
-                                           bottomLeftPoint: bL,
+                    let rect = Rect(
+                        origin: bL,
+                        size: Size(width: plotLegend.legendTextSize, height: plotLegend.legendTextSize)
+                    )
+                    renderer.drawSolidRect(rect,
                                            fillColor: series[i].color,
                                            hatchPattern: .none,
                                            isOriginShifted: false)


### PR DESCRIPTION
This massively simplifies lots of layout maths (especially in BarChart, as you might expect).

I'm currently working on tweaking the layout so that x/y axis labels don't intersect with markers, and stuff like that is made much easier with a `Rect` type.