### PR TITLE
Fix base64 PNG rendering

### DIFF
--- a/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
+++ b/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
@@ -7,10 +7,11 @@ public class AGGRenderer: Renderer{
     public var offset = zeroPoint
     public var imageSize: Size {
         willSet {
-            agg_object = initializePlot(newValue.width, newValue.height, fontPath)
+          delete_plot(agg_object);
+          agg_object = initializePlot(newValue.width, newValue.height, fontPath)
         }
     }
-    var agg_object: UnsafeRawPointer
+    var agg_object: UnsafeMutableRawPointer
     var fontPath = ""
 
     public init(width w: Float = 1000, height h: Float = 660, fontPath: String = "") {
@@ -272,7 +273,7 @@ public class AGGRenderer: Renderer{
     }
 
     deinit {
-        delete_buffer(agg_object)
+        delete_plot(agg_object)
     }
 
 }

--- a/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
+++ b/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
@@ -239,21 +239,36 @@ public class AGGRenderer: Renderer{
     }
 
     public func drawOutput(fileName name: String) throws {
-        var errorDescPtr = UnsafePointer<Int8>(bitPattern: 0)
+        var errorDescPtr: UnsafePointer<Int8>?
         let err = save_image(name, &errorDescPtr, agg_object)
         if err != 0, let errorDescPtr = errorDescPtr {
             throw DrawOutputError(errorCode: err, description: String(cString: errorDescPtr))
         }
     }
 
-    public func base64Png() -> String{
-        let pngBufferPointer: UnsafePointer<UInt8> = get_png_buffer(agg_object)
-        let bufferSize: Int = Int(get_png_buffer_size(agg_object))
-        return Data(
-            bytesNoCopy: UnsafeMutableRawPointer(mutating: pngBufferPointer),
-            count: bufferSize,
-            deallocator: .none
-        ).base64EncodedString(options: .lineLength64Characters)
+    public func base64Png() -> String {
+      var _bufferPtr: UnsafeMutablePointer<UInt8>?
+      var errorDescPtr: UnsafePointer<Int8>?
+      var bufferSize = 0
+      
+      let err = create_png_buffer(&_bufferPtr, &bufferSize, &errorDescPtr, agg_object)
+      guard let bufferPtr = _bufferPtr, err == 0 else {
+        // We'll probably never make this throwing, but log the error all the same.
+        print(
+          errorDescPtr.map { "Error rendering image: \(String(cString: $0))"} ??
+          "lodepng failed to render, but didn't produce an error."
+        )
+        return ""
+      }
+      
+      let base64String = Data(
+        bytesNoCopy: UnsafeMutableRawPointer(mutating: bufferPtr),
+        count: bufferSize,
+        deallocator: .none
+      ).base64EncodedString(options: .lineLength64Characters)
+      
+      free_png_buffer(&_bufferPtr)
+      return base64String
     }
 
     deinit {

--- a/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
+++ b/Sources/AGGRenderer/AGGRenderer/AGGRenderer.swift
@@ -266,7 +266,7 @@ public class AGGRenderer: Renderer{
         bytesNoCopy: UnsafeMutableRawPointer(mutating: bufferPtr),
         count: bufferSize,
         deallocator: .none
-      ).base64EncodedString(options: .lineLength64Characters)
+      ).base64EncodedString()
       
       free_png_buffer(&_bufferPtr)
       return base64String

--- a/Sources/AGGRenderer/CAGGRenderer/CAGGRenderer.cpp
+++ b/Sources/AGGRenderer/CAGGRenderer/CAGGRenderer.cpp
@@ -2,8 +2,12 @@
 #include "CPPAGGRenderer.h"
 #include <iostream>
 
-const void * initializePlot(float w, float h, const char* fontPath){
+void * initializePlot(float w, float h, const char* fontPath){
   return CPPAGGRenderer::initializePlot(w, h, fontPath);
+}
+
+void delete_plot(void *object){
+  CPPAGGRenderer::delete_plot(object);
 }
 
 void draw_rect(const float *x, const float *y, float thickness, float r, float g, float b, float a, const void *object){
@@ -52,8 +56,4 @@ unsigned create_png_buffer(unsigned char** output, size_t *outputSize, const cha
 
 void free_png_buffer(unsigned char** output) {
   CPPAGGRenderer::free_png_buffer(output);
-}
-
-void delete_buffer(const void *object){
-  CPPAGGRenderer::delete_buffer(object);
 }

--- a/Sources/AGGRenderer/CAGGRenderer/CAGGRenderer.cpp
+++ b/Sources/AGGRenderer/CAGGRenderer/CAGGRenderer.cpp
@@ -46,12 +46,12 @@ unsigned save_image(const char *s, const char** errorDesc, const void *object){
   return CPPAGGRenderer::save_image(s, errorDesc, object);
 }
 
-const unsigned char* get_png_buffer(const void *object){
-  return CPPAGGRenderer::get_png_buffer(object);
+unsigned create_png_buffer(unsigned char** output, size_t *outputSize, const char** errorDesc, const void *object) {
+  return CPPAGGRenderer::create_png_buffer(output, outputSize, errorDesc, object);
 }
 
-int get_png_buffer_size(const void *object){
-  return CPPAGGRenderer::get_png_buffer_size(object);
+void free_png_buffer(unsigned char** output) {
+  CPPAGGRenderer::free_png_buffer(output);
 }
 
 void delete_buffer(const void *object){

--- a/Sources/AGGRenderer/CAGGRenderer/include/CAGGRenderer.h
+++ b/Sources/AGGRenderer/CAGGRenderer/include/CAGGRenderer.h
@@ -4,7 +4,9 @@
 extern "C"  {
 #endif
 
-const void * initializePlot(float w, float h, const char* fontPath);
+void * initializePlot(float w, float h, const char* fontPath);
+
+void delete_plot(void *object);
 
 void draw_rect(const float *x, const float *y, float thickness, float r, float g, float b, float a, const void *object);
 
@@ -29,8 +31,6 @@ unsigned save_image(const char *s, const char** errorDesc, const void *object);
 unsigned create_png_buffer(unsigned char** output, size_t *outputSize, const char** errorDesc, const void *object);
 
 void free_png_buffer(unsigned char** output);
-
-void delete_buffer(const void *object);
 
 #ifdef __cplusplus
 }

--- a/Sources/AGGRenderer/CAGGRenderer/include/CAGGRenderer.h
+++ b/Sources/AGGRenderer/CAGGRenderer/include/CAGGRenderer.h
@@ -1,4 +1,5 @@
 #include<stdbool.h>
+#include<stddef.h>
 #ifdef __cplusplus
 extern "C"  {
 #endif
@@ -25,9 +26,9 @@ void get_text_size(const char *s, float size, float* outW, float* outH, const vo
 
 unsigned save_image(const char *s, const char** errorDesc, const void *object);
 
-const unsigned char* get_png_buffer(const void *object);
+unsigned create_png_buffer(unsigned char** output, size_t *outputSize, const char** errorDesc, const void *object);
 
-int get_png_buffer_size(const void *object);
+void free_png_buffer(unsigned char** output);
 
 void delete_buffer(const void *object);
 

--- a/Sources/AGGRenderer/CPPAGGRenderer/CPPAGGRenderer.cpp
+++ b/Sources/AGGRenderer/CPPAGGRenderer/CPPAGGRenderer.cpp
@@ -479,10 +479,17 @@ namespace CPPAGGRenderer{
 
   };
 
-  const void * initializePlot(float w, float h, const char* fontPath){
+  void * initializePlot(float w, float h, const char* fontPath){
     Plot *plot = new Plot(w, h, fontPath);
     memset(plot->buffer, 255, plot->frame_width*plot->frame_height*3);
     return (void *)plot;
+  }
+
+  void delete_plot(void *object) {
+    Plot *plot = (Plot *)object;
+    plot -> delete_buffer();
+    delete plot;
+    object = 0;
   }
 
   void draw_rect(const float *x, const float *y, float thickness, float r, float g, float b, float a,
@@ -544,11 +551,6 @@ namespace CPPAGGRenderer{
   void free_png_buffer(unsigned char** buffer) {
     if (buffer) { free(*buffer); }
     *buffer = 0;
-  }
-
-  void delete_buffer(const void *object){
-    Plot *plot = (Plot *)object;
-    plot -> delete_buffer();
   }
 
 }

--- a/Sources/AGGRenderer/CPPAGGRenderer/CPPAGGRenderer.cpp
+++ b/Sources/AGGRenderer/CPPAGGRenderer/CPPAGGRenderer.cpp
@@ -72,8 +72,6 @@ namespace CPPAGGRenderer{
   }
 
   class Plot{
-
-  public:
     agg::rasterizer_scanline_aa<> m_ras;
     agg::scanline_p8              m_sl_p8;
     agg::line_cap_e buttCap = agg::butt_cap;
@@ -99,7 +97,9 @@ namespace CPPAGGRenderer{
     agg::int8u*           m_pattern;
     agg::rendering_buffer m_pattern_rbuf;
     renderer_base_pre rb_pre;
-
+    
+  public:
+    
     Plot(float width, float height, const char* fontPathPtr) :
     m_feng(),
     m_fman(m_feng),
@@ -108,10 +108,8 @@ namespace CPPAGGRenderer{
     frame_width(width),
     frame_height(height)
     {
-      if (buffer != NULL) {
-        delete[] buffer;
-      }
       buffer = new unsigned char[frame_width*frame_height*3];
+      memset(buffer, 255, frame_width*frame_height*3);
       m_curves.approximation_scale(2.0);
       m_contour.auto_detect_orientation(false);
       fontPath = fontPathPtr;
@@ -120,6 +118,10 @@ namespace CPPAGGRenderer{
         string dir_path = file_path.substr(0, file_path.rfind("/"));
         fontPath = dir_path.append("/Roboto-Regular.ttf");
       }
+    }
+    
+    ~Plot() {
+      delete [] buffer;
     }
 
     void generate_pattern(float r, float g, float b, float a, int hatch_pattern){
@@ -472,22 +474,15 @@ namespace CPPAGGRenderer{
     unsigned create_png_buffer(unsigned char** output, size_t *outputSize, const char** errorDesc) {
       return write_png_memory(buffer, frame_width, frame_height, output, outputSize, errorDesc);
     }
-
-    void delete_buffer(){
-      delete[] buffer;
-    }
-
   };
 
   void * initializePlot(float w, float h, const char* fontPath){
     Plot *plot = new Plot(w, h, fontPath);
-    memset(plot->buffer, 255, plot->frame_width*plot->frame_height*3);
     return (void *)plot;
   }
 
   void delete_plot(void *object) {
     Plot *plot = (Plot *)object;
-    plot -> delete_buffer();
     delete plot;
     object = 0;
   }
@@ -552,5 +547,4 @@ namespace CPPAGGRenderer{
     if (buffer) { free(*buffer); }
     *buffer = 0;
   }
-
 }

--- a/Sources/AGGRenderer/CPPAGGRenderer/include/CPPAGGRenderer.h
+++ b/Sources/AGGRenderer/CPPAGGRenderer/include/CPPAGGRenderer.h
@@ -1,3 +1,5 @@
+#include <stddef.h>
+
 namespace CPPAGGRenderer{
 
   const void * initializePlot(float w, float h, const char* fontPath);
@@ -22,9 +24,9 @@ namespace CPPAGGRenderer{
 
   unsigned save_image(const char *s, const char** errorDesc, const void *object);
 
-  const unsigned char* get_png_buffer(const void *object);
+  unsigned create_png_buffer(unsigned char **output, size_t *outputSize, const char **errorDesc, const void *object);
 
-  int get_png_buffer_size(const void *object);
+  void free_png_buffer(unsigned char **buffer);
 
   void delete_buffer(const void *object);
 

--- a/Sources/AGGRenderer/CPPAGGRenderer/include/CPPAGGRenderer.h
+++ b/Sources/AGGRenderer/CPPAGGRenderer/include/CPPAGGRenderer.h
@@ -2,7 +2,9 @@
 
 namespace CPPAGGRenderer{
 
-  const void * initializePlot(float w, float h, const char* fontPath);
+  void * initializePlot(float w, float h, const char* fontPath);
+
+  void delete_plot(void *object);
 
   void draw_rect(const float *x, const float *y, float thickness, float r, float g, float b, float a, const void *object);
 
@@ -27,7 +29,5 @@ namespace CPPAGGRenderer{
   unsigned create_png_buffer(unsigned char **output, size_t *outputSize, const char **errorDesc, const void *object);
 
   void free_png_buffer(unsigned char **buffer);
-
-  void delete_buffer(const void *object);
 
 }

--- a/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
+++ b/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
@@ -5,8 +5,6 @@ import AGGRenderer
 
 extension AGGRendererTests {
   
-  /// **XFAIL**
-  ///
   /// Tests that base64 encoding is accurate by drawing a known graph directly in to
   /// a PNG buffer (no files), then verifying the base64-encoded data matches that from
   /// the reference file.
@@ -36,9 +34,9 @@ extension AGGRendererTests {
       .appendingPathComponent(fileName)
       .appendingPathExtension(KnownRenderer.agg.fileExtension)
     let referenceBase64 = try Data(contentsOf: referenceFile)
-      .base64EncodedString()//(options: .lineLength64Characters)
+      .base64EncodedString(options: .lineLength64Characters)
     
-    //XCTAssertEqual(outputBase64, referenceBase64)
+    XCTAssertEqual(outputBase64, referenceBase64)
   }
 }
 

--- a/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
+++ b/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
@@ -20,7 +20,7 @@ extension AGGRendererTests {
     let renderer = AGGRenderer()
     barGraph.drawGraph(renderer: renderer)
     let outputBase64 = renderer.base64Png()
-    XCTAssertEqual(outputBase64.count, 47397)
+    XCTAssertEqual(outputBase64.count, 46668)
     
     // First, sanity check: ensure *we* can decode the string.
     guard let _ = Data(base64Encoded: outputBase64, options: .ignoreUnknownCharacters) else {
@@ -34,7 +34,7 @@ extension AGGRendererTests {
       .appendingPathComponent(fileName)
       .appendingPathExtension(KnownRenderer.agg.fileExtension)
     let referenceBase64 = try Data(contentsOf: referenceFile)
-      .base64EncodedString(options: .lineLength64Characters)
+      .base64EncodedString()
     
     XCTAssertEqual(outputBase64, referenceBase64)
   }


### PR DESCRIPTION
`lodepng_encode_memory` gives us a buffer which is (according to the now-working test) indistinguishable from the file on disk.

I also removed the base64 newlines - it makes it harder to debug, because lots of tools don't them (besides, they increase the size, as the test also shows). Are they required for Colab/Jupyter?

Colab still doesn't display the graphs (maybe Jupyter does?), but it doesn't look like our problem; I pasted the base64 string in to https://codebeautify.org/base64-to-image-converter (basically, what came up when I googled "base64 png viewer"), and it displays just fine.

Also fixed leaking plots when setting image size, and leaking non-buffer plot memory in general.