### PR TITLE
docs: update dependency addition

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ The resultant images are stored in a directory named  `output`. The `Tests` fold
 Add the library to your projects dependencies in the Package.swift file as shown below.
 ```swift
 dependencies: [
-        .package(url: "https://github.com/KarthikRIyer/swiftplot.git", .exact("1.0.0")),
+        .package(url: "https://github.com/KarthikRIyer/swiftplot.git", .branch("master")),
     ],
 ```
 


### PR DESCRIPTION
The 1.0.0 release has a separate dependency on CFreeType that seems to have a problem. A recent PR moved that dependency into the package itself, as SwiftPM now supports system library targets. This solved the issue. SwiftPlot uses Anti-Grain Geometry (AGG), a C++ library as a rendering backend, which in turn uses freetype to render text.