### PR TITLE
feat: add annotation support

### DIFF
--- a/Sources/SwiftPlot/GraphLayout.swift
+++ b/Sources/SwiftPlot/GraphLayout.swift
@@ -12,6 +12,7 @@ public struct GraphLayout {
     var backgroundColor: Color = .white
     var plotBackgroundColor: Color?
     var plotTitle = PlotTitle()
+    var plotAnnotation = PlotAnnotation()
     var plotLabel  = PlotLabel()
     var plotLegend = PlotLegend()
     var plotBorder = PlotBorder()
@@ -39,6 +40,7 @@ public struct GraphLayout {
         var yLabelLocation: Point?
         var y2LabelLocation: Point?
         var titleLocation: Point?
+        var annotationLocation: Point?
         
         var plotMarkers = PlotMarkers()
         var xMarkersTextLocation = [Point]()
@@ -200,6 +202,17 @@ public struct GraphLayout {
                               location: titleLocation,
                               textSize: plotTitle.size,
                               color: plotTitle.color,
+                              strokeWidth: 1.2,
+                              angle: 0)
+        }
+    }
+
+    func drawAnnotation(results: Results, renderer: Renderer) {
+        if let annotationLocation = results.annotationLocation {
+            renderer.drawText(text: plotAnnotation.annotation,
+                              location: annotationLocation,
+                              textSize: plotAnnotation.size,
+                              color: plotAnnotation.color,
                               strokeWidth: 1.2,
                               angle: 0)
         }
@@ -392,6 +405,10 @@ extension HasGraphLayout {
         get { layout.plotTitle }
         set { layout.plotTitle = newValue }
     }
+    public var plotAnnotation : PlotAnnotation {
+        get { layout.plotAnnotation }
+        set {layout.plotAnnotation = newValue }
+    }
     public var plotLabel: PlotLabel {
         get { layout.plotLabel }
         set { layout.plotLabel = newValue }
@@ -439,6 +456,7 @@ extension Plot where Self: HasGraphLayout {
             drawData(markers: results.plotMarkers, size: results.plotBorderRect.size, renderer: renderer)
         }
         layout.drawForeground(results: results, renderer: renderer)
+        layout.drawAnnotation(results: results, renderer: renderer)
     }
     
 }

--- a/Sources/SwiftPlot/PlotStyleHelpers.swift
+++ b/Sources/SwiftPlot/PlotStyleHelpers.swift
@@ -20,6 +20,15 @@ public struct PlotTitle {
     }
 }
 
+public struct PlotAnnotation {
+    public var annotation = ""
+    public var color = Color.black
+    public var size: Float = 20
+    public init(_ annotation: String = ""){
+        self.annotation = annotation
+    }
+}
+
 public struct PlotLabel {
     public var xLabel = ""
     public var yLabel = ""


### PR DESCRIPTION
Hi,

This is my PR for adding the watermark/annotation features in the graph plots. 

I tried to mimic the style of the ```plotTitle``` attribute as they were very similar in function.

I'm a bit confused on what @karwa meant by type ```[Annotation]```. Would that be an argument in the ```drawAnnotation``` function in line 210 of ```GraphLayout.swift```? Would I also have to define a structure of that type somehow? Currently, I just have a member ```plotAnnotation``` that contains the annotation, color of text, size, etc.

Running ```swift build``` on the repo returns without any error, however when I was testing using this function in another directory with my fork of swiftplot in the dependencies, when I set the annotation using ```lineGraph.plotAnnotation.annotation = "HELLO WORLD"```, running ```swift run``` returns an error saying ```error: value of type 'LineGraph<Float, Float>' has no member 'plotAnnotation'```. However, I believe that I have defined the member ```plotAnnotation``` in line 15 of ```GraphLayout.swift```. Is there something that I am missing here?

Thanks so much for your help and understanding, I'm completely new to Swift and its syntax.