### PR TITLE
Upload test artefacts to GitHub

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -17,4 +17,10 @@ jobs:
     - name: Build
       run: swift build -v
     - name: Run tests
-      run: swift test -v
+      run: SWIFTPLOT_TEST_OUTPUT=/private/var/tmp/swiftplot swift test -v
+    - name: Upload test artefacts
+      uses: actions/upload-artifact@v1
+      if: always()
+      with:
+        name: images
+        path: /private/var/tmp/swiftplot/

--- a/Tests/SwiftPlotTests/SwiftPlotTestCase.swift
+++ b/Tests/SwiftPlotTests/SwiftPlotTestCase.swift
@@ -39,7 +39,9 @@ enum KnownRenderer {
 }
 
 // TODO: Possibly allow setting this via a command-line flag?
-fileprivate let outputDirectoryRoot: String = "./output/"
+fileprivate let outputDirectoryRoot: String = { () -> String? in
+  ProcessInfo.processInfo.environment["SWIFTPLOT_TEST_OUTPUT"]
+}() ?? "./output/"
 
 fileprivate let referenceDirectoryRoot: URL = {
   // #file = SwiftPlotTests/swiftPlotTestCase.swift


### PR DESCRIPTION
Upload the results of CI runs to GitHub as test artefacts.

This is also useful for people who don't have access to a Mac box, so they can access the Quartz renders which GitHub's machines produce.