### PR TITLE
Convert the plots to value types

### DIFF
--- a/Sources/SwiftPlot/Axis.swift
+++ b/Sources/SwiftPlot/Axis.swift
@@ -1,6 +1,5 @@
-public class Axis<T,U>{
-    public var scaleX: Float = 1
-    public var scaleY: Float = 1
+public struct Axis<T,U>{
+
     public var series = [Series<T,U>]()
     public init(){}
 

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -1,7 +1,7 @@
 import Foundation
 
 // class defining a barGraph and all it's logic
-public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
+public struct BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
 
     let MAX_DIV: Float = 50
 
@@ -26,10 +26,10 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
         set { layout.enablePrimaryAxisGrid = newValue }
     }
     
-    public func addSeries(_ s: Series<T,U>){
+    public mutating func addSeries(_ s: Series<T,U>){
         series = s
     }
-    public func addStackSeries(_ s: Series<T,U>) {
+    public mutating func addStackSeries(_ s: Series<T,U>) {
         if (series.count != 0 && series.count == s.count) {
             stackSeries.append(s)
         }
@@ -37,7 +37,7 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
             print("Stack point count does not match the Series point count.")
         }
     }
-    public func addStackSeries(_ x: [U],
+    public mutating func addStackSeries(_ x: [U],
                                label: String,
                                color: Color = .lightBlue,
                                hatchPattern: BarGraphSeriesOptions.Hatching = .none) {
@@ -51,7 +51,7 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
                             hatchPattern: hatchPattern)
         addStackSeries(s)
     }
-    public func addSeries(values: [Pair<T,U>],
+    public mutating func addSeries(values: [Pair<T,U>],
                           label: String,
                           color: Color = Color.lightBlue,
                           hatchPattern: BarGraphSeriesOptions.Hatching = .none,
@@ -63,7 +63,7 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
         addSeries(s)
         self.graphOrientation = graphOrientation
     }
-    public func addSeries(_ x: [T],
+    public mutating func addSeries(_ x: [T],
                           _ y: [U],
                           label: String,
                           color: Color = Color.lightBlue,

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -16,6 +16,10 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     
     var series = Series<T,U>()
     var stackSeries = [Series<T,U>]()
+    
+    public var series_scaledValues = [Pair<T,U>]()
+    public var stackSeries_scaledValues = [[Pair<T,U>]]()
+
     var scaleY: Float = 1
     var scaleX: Float = 1
     var barWidth : Int = 0
@@ -174,18 +178,19 @@ extension BarGraph: HasGraphLayout {
 
             // scale points to be plotted according to plot size
             let scaleYInv: Float = 1.0/scaleY
-            series.scaledValues.removeAll();
+            series_scaledValues.removeAll();
             for j in 0..<series.count {
                 let scaledPair = Pair<T,U>(series[j].x,
                                            series[j].y*U(scaleYInv) + U(origin.y))
-                series.scaledValues.append(scaledPair)
+                series_scaledValues.append(scaledPair)
             }
+            stackSeries_scaledValues.removeAll()
             for index in 0..<stackSeries.count {
-                stackSeries[index].scaledValues.removeAll()
+                stackSeries_scaledValues.append([])
                 for j in 0..<(stackSeries[index]).count {
                     let scaledPair = Pair<T,U>((stackSeries[index])[j].x,
                                                ((stackSeries[index])[j].y)*U(scaleYInv)+U(origin.y))
-                    stackSeries[index].scaledValues.append(scaledPair)
+                    stackSeries_scaledValues[index].append(scaledPair)
                 }
             }
         }
@@ -258,18 +263,19 @@ extension BarGraph: HasGraphLayout {
 
             // scale points to be plotted according to plot size
             let scaleXInv: Float = 1.0/scaleX
-            series.scaledValues.removeAll();
+            series_scaledValues.removeAll();
             for j in 0..<series.count {
                 let scaledPair = Pair<T,U>(series[j].x,
                                            series[j].y*U(scaleXInv)+U(origin.x))
-                series.scaledValues.append(scaledPair)
+                series_scaledValues.append(scaledPair)
             }
+            stackSeries_scaledValues.removeAll()
             for index in 0..<stackSeries.count {
-                stackSeries[index].scaledValues.removeAll()
+                stackSeries_scaledValues.append([])
                 for j in 0..<(stackSeries[index]).count {
                     let scaledPair = Pair<T,U>((stackSeries[index])[j].x,
                                                 (stackSeries[index])[j].y*U(scaleXInv)+U(origin.x))
-                    stackSeries[index].scaledValues.append(scaledPair)
+                    stackSeries_scaledValues[index].append(scaledPair)
                 }
             }
         }
@@ -288,7 +294,7 @@ extension BarGraph: HasGraphLayout {
                         origin.y),
                     size: Size(
                         width: Float(barWidth - space),
-                        height: Float(series.scaledValues[index].y) - origin.y)
+                        height: Float(series_scaledValues[index].y) - origin.y)
                 )
                 if (rect.size.height >= 0) {
                     currentHeightPositive = rect.size.height
@@ -299,8 +305,8 @@ extension BarGraph: HasGraphLayout {
                 renderer.drawSolidRect(rect,
                                        fillColor: series.color,
                                        hatchPattern: series.barGraphSeriesOptions.hatchPattern)
-                for s in stackSeries {
-                    let stackValue = Float(s.scaledValues[index].y)
+                for i in 0..<stackSeries.count {
+                    let stackValue = Float(stackSeries_scaledValues[i][index].y)
                     if (stackValue - origin.y >= 0) {
                         rect.origin.y = origin.y + currentHeightPositive
                         rect.size.height = stackValue - origin.y
@@ -312,8 +318,8 @@ extension BarGraph: HasGraphLayout {
                         currentHeightNegative += stackValue
                     }
                     renderer.drawSolidRect(rect,
-                                           fillColor: s.color,
-                                           hatchPattern: s.barGraphSeriesOptions.hatchPattern)
+                                           fillColor: stackSeries[i].color,
+                                           hatchPattern: stackSeries[i].barGraphSeriesOptions.hatchPattern)
                 }
             }
         }
@@ -324,7 +330,7 @@ extension BarGraph: HasGraphLayout {
                 var rect = Rect(
                     origin: Point(origin.x, markers.yMarkers[index]-Float(barWidth)*Float(0.5)+Float(space)*Float(0.5)),
                     size: Size(
-                        width: Float(series.scaledValues[index].y) - origin.x,
+                        width: Float(series_scaledValues[index].y) - origin.x,
                         height: Float(barWidth - space))
                 )
                 if (rect.size.width >= 0) {
@@ -336,8 +342,8 @@ extension BarGraph: HasGraphLayout {
                 renderer.drawSolidRect(rect,
                                        fillColor: series.color,
                                        hatchPattern: series.barGraphSeriesOptions.hatchPattern)
-                for s in stackSeries {
-                    let stackValue = Float(s.scaledValues[index].y)
+                for i in 0..<stackSeries.count {
+                    let stackValue = Float(stackSeries_scaledValues[i][index].y)
                     if (stackValue - origin.x >= 0) {
                         rect.origin.x = origin.x + currentWidthPositive
                         rect.size.width = stackValue - origin.x
@@ -349,8 +355,8 @@ extension BarGraph: HasGraphLayout {
                         currentWidthNegative += stackValue
                     }
                     renderer.drawSolidRect(rect,
-                                           fillColor: s.color,
-                                           hatchPattern: s.barGraphSeriesOptions.hatchPattern)
+                                           fillColor: stackSeries[i].color,
+                                           hatchPattern: stackSeries[i].barGraphSeriesOptions.hatchPattern)
                 }
             }
         }

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -17,14 +17,6 @@ public class BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     var series = Series<T,U>()
     var stackSeries = [Series<T,U>]()
     
-    public var series_scaledValues = [Pair<T,U>]()
-    public var stackSeries_scaledValues = [[Pair<T,U>]]()
-
-    var scaleY: Float = 1
-    var scaleX: Float = 1
-    var barWidth : Int = 0
-    var origin = zeroPoint
-
     public init(enableGrid: Bool = false){
         self.enableGrid = enableGrid
     }
@@ -93,7 +85,12 @@ extension BarGraph: HasGraphLayout {
     }
     
     public struct DrawingData {
-        
+        var series_scaledValues = [Pair<T,U>]()
+        var stackSeries_scaledValues = [[Pair<T,U>]]()
+        var scaleY: Float = 1
+        var scaleX: Float = 1
+        var barWidth : Int = 0
+        var origin = zeroPoint
     }
     
     // functions implementing plotting logic
@@ -109,12 +106,12 @@ extension BarGraph: HasGraphLayout {
 
         guard series.count > 0 else { return (results, markers) }
         if (graphOrientation == .vertical) {
-            barWidth = Int(round(size.width/Float(series.count)))
+            results.barWidth = Int(round(size.width/Float(series.count)))
             maximumY = maxY(points: series.values)
             minimumY = minY(points: series.values)
         }
         else{
-            barWidth = Int(round(size.height/Float(series.count)))
+            results.barWidth = Int(round(size.height/Float(series.count)))
             maximumX = maxY(points: series.values)
             minimumX = minY(points: series.values)
         }
@@ -134,16 +131,16 @@ extension BarGraph: HasGraphLayout {
             }
 
             if (minimumY >= U(0)) {
-                origin = zeroPoint
+                results.origin = zeroPoint
                 minimumY = U(0)
             }
             else{
-                origin = Point(0.0,
+                results.origin = Point(0.0,
                                (size.height/Float(maximumY-minimumY))*Float(U(-1)*minimumY))
             }
 
             let topScaleMargin: Float = size.height * 0.1
-            scaleY = Float(maximumY - minimumY) / (size.height - topScaleMargin);
+            results.scaleY = Float(maximumY - minimumY) / (size.height - topScaleMargin);
 
             let nD1: Int = max(getNumberOfDigits(Float(maximumY)), getNumberOfDigits(Float(minimumY)))
             var v1: Float
@@ -155,42 +152,42 @@ extension BarGraph: HasGraphLayout {
                 v1 = Float(pow(Float(10), Float(0)))
             }
 
-            let nY: Float = v1/scaleY
+            let nY: Float = v1/results.scaleY
             var inc1: Float = nY
             if(size.height/nY > MAX_DIV){
                 inc1 = (size.height/nY)*inc1/MAX_DIV
             }
 
-            var yM = Float(origin.y)
+            var yM = Float(results.origin.y)
             while yM<=size.height {
                 if(yM+inc1<0.0 || yM<0.0){
                     yM = yM + inc1
                     continue
                 }
                 markers.yMarkers.append(yM)
-                markers.yMarkersText.append("\(round(scaleY*(yM-origin.y)))")
+                markers.yMarkersText.append("\(round(results.scaleY*(yM-results.origin.y)))")
                 yM = yM + inc1
             }
-            yM = origin.y - inc1
+            yM = results.origin.y - inc1
             while yM>0.0 {
                 markers.yMarkers.append(yM)
-                markers.yMarkersText.append("\(round(scaleY*(yM-origin.y)))")
+                markers.yMarkersText.append("\(round(results.scaleY*(yM-results.origin.y)))")
                 yM = yM - inc1
             }
 
             for i in 0..<series.count {
-                markers.xMarkers.append(Float(i*barWidth) + Float(barWidth)*Float(0.5))
+                markers.xMarkers.append(Float(i*results.barWidth) + Float(results.barWidth)*Float(0.5))
                 markers.xMarkersText.append("\(series[i].x)")
             }
 
             // scale points to be plotted according to plot size
-            let scaleYInv: Float = 1.0/scaleY
-            series_scaledValues = series.values.map { pt in
-                Pair<T,U>(pt.x, pt.y*U(scaleYInv) + U(origin.y))
+            let scaleYInv: Float = 1.0/results.scaleY
+            results.series_scaledValues = series.values.map { pt in
+                Pair<T,U>(pt.x, pt.y*U(scaleYInv) + U(results.origin.y))
             }
-            stackSeries_scaledValues = stackSeries.map { series in
+            results.stackSeries_scaledValues = stackSeries.map { series in
                 series.values.map { pt in
-                    Pair<T,U>(pt.x, (pt.y)*U(scaleYInv)+U(origin.y))
+                    Pair<T,U>(pt.x, (pt.y)*U(scaleYInv)+U(results.origin.y))
                 }
             }
         }
@@ -213,15 +210,15 @@ extension BarGraph: HasGraphLayout {
             }
 
             if minimumX >= U(0) {
-                origin = zeroPoint
+                results.origin = zeroPoint
                 minimumX = U(0)
             }
             else{
-                origin = Point((size.width/Float(maximumX-minimumX))*Float(U(-1)*minimumX), 0.0)
+                results.origin = Point((size.width/Float(maximumX-minimumX))*Float(U(-1)*minimumX), 0.0)
             }
 
             let rightScaleMargin: Float = size.width * 0.1
-            scaleX = Float(maximumX - minimumX) / (size.width - rightScaleMargin)
+            results.scaleX = Float(maximumX - minimumX) / (size.width - rightScaleMargin)
 
             let nD1: Int = max(getNumberOfDigits(Float(maximumX)), getNumberOfDigits(Float(minimumX)))
             var v1: Float
@@ -233,42 +230,42 @@ extension BarGraph: HasGraphLayout {
                 v1 = Float(pow(Float(10), Float(0)))
             }
 
-            let nX: Float = v1/scaleX
+            let nX: Float = v1/results.scaleX
             var inc1: Float = nX
             if(size.width/nX > MAX_DIV){
                 inc1 = (size.width/nX)*inc1/MAX_DIV
             }
 
-            var xM = origin.x
+            var xM = results.origin.x
             while xM<=size.width {
                 if(xM+inc1<0.0 || xM<0.0){
                     xM = xM + inc1
                     continue
                 }
                 markers.xMarkers.append(xM)
-                markers.xMarkersText.append("\(ceil(scaleX*(xM-origin.x)))")
+                markers.xMarkersText.append("\(ceil(results.scaleX*(xM-results.origin.x)))")
                 xM = xM + inc1
             }
-            xM = origin.x - inc1
+            xM = results.origin.x - inc1
             while xM>0.0 {
                 markers.xMarkers.append(xM)
-                markers.xMarkersText.append("\(floor(scaleX*(xM-origin.x)))")
+                markers.xMarkersText.append("\(floor(results.scaleX*(xM-results.origin.x)))")
                 xM = xM - inc1
             }
 
             for i in 0..<series.count {
-                markers.yMarkers.append(Float(i*barWidth) + Float(barWidth)*Float(0.5))
+                markers.yMarkers.append(Float(i*results.barWidth) + Float(results.barWidth)*Float(0.5))
                 markers.yMarkersText.append("\(series[i].x)")
             }
 
             // scale points to be plotted according to plot size
-            let scaleXInv: Float = 1.0/scaleX
-            series_scaledValues = series.values.map { pt in
-                Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(origin.x))
+            let scaleXInv: Float = 1.0/results.scaleX
+            results.series_scaledValues = series.values.map { pt in
+                Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(results.origin.x))
             }
-            stackSeries_scaledValues = stackSeries.map { series in
+            results.stackSeries_scaledValues = stackSeries.map { series in
                 series.values.map { pt in
-                    Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(origin.x))
+                    Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(results.origin.x))
                 }
             }
         }
@@ -278,16 +275,16 @@ extension BarGraph: HasGraphLayout {
     //functions to draw the plot
     public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
         if (graphOrientation == .vertical) {
-            for index in 0..<series.count {
+            for index in 0..<data.series_scaledValues.count {
                 var currentHeightPositive: Float = 0
                 var currentHeightNegative: Float = 0
                 var rect = Rect(
                     origin: Point(
-                        markers.xMarkers[index]-Float(barWidth)*Float(0.5)+Float(space)*Float(0.5),
-                        origin.y),
+                        markers.xMarkers[index]-Float(data.barWidth)*Float(0.5)+Float(space)*Float(0.5),
+                        data.origin.y),
                     size: Size(
-                        width: Float(barWidth - space),
-                        height: Float(series_scaledValues[index].y) - origin.y)
+                        width: Float(data.barWidth - space),
+                        height: Float(data.series_scaledValues[index].y) - data.origin.y)
                 )
                 if (rect.size.height >= 0) {
                     currentHeightPositive = rect.size.height
@@ -298,16 +295,16 @@ extension BarGraph: HasGraphLayout {
                 renderer.drawSolidRect(rect,
                                        fillColor: series.color,
                                        hatchPattern: series.barGraphSeriesOptions.hatchPattern)
-                for i in 0..<stackSeries.count {
-                    let stackValue = Float(stackSeries_scaledValues[i][index].y)
-                    if (stackValue - origin.y >= 0) {
-                        rect.origin.y = origin.y + currentHeightPositive
-                        rect.size.height = stackValue - origin.y
+                for i in 0..<data.stackSeries_scaledValues.count {
+                    let stackValue = Float(data.stackSeries_scaledValues[i][index].y)
+                    if (stackValue - data.origin.y >= 0) {
+                        rect.origin.y = data.origin.y + currentHeightPositive
+                        rect.size.height = stackValue - data.origin.y
                         currentHeightPositive += stackValue
                     }
                     else {
-                        rect.origin.y = origin.y - currentHeightNegative - stackValue
-                        rect.size.height = stackValue - origin.y
+                        rect.origin.y = data.origin.y - currentHeightNegative - stackValue
+                        rect.size.height = stackValue - data.origin.y
                         currentHeightNegative += stackValue
                     }
                     renderer.drawSolidRect(rect,
@@ -321,10 +318,10 @@ extension BarGraph: HasGraphLayout {
                 var currentWidthPositive: Float = 0
                 var currentWidthNegative: Float = 0
                 var rect = Rect(
-                    origin: Point(origin.x, markers.yMarkers[index]-Float(barWidth)*Float(0.5)+Float(space)*Float(0.5)),
+                    origin: Point(data.origin.x, markers.yMarkers[index]-Float(data.barWidth)*Float(0.5)+Float(space)*Float(0.5)),
                     size: Size(
-                        width: Float(series_scaledValues[index].y) - origin.x,
-                        height: Float(barWidth - space))
+                        width: Float(data.series_scaledValues[index].y) - data.origin.x,
+                        height: Float(data.barWidth - space))
                 )
                 if (rect.size.width >= 0) {
                     currentWidthPositive = rect.size.width
@@ -336,15 +333,15 @@ extension BarGraph: HasGraphLayout {
                                        fillColor: series.color,
                                        hatchPattern: series.barGraphSeriesOptions.hatchPattern)
                 for i in 0..<stackSeries.count {
-                    let stackValue = Float(stackSeries_scaledValues[i][index].y)
-                    if (stackValue - origin.x >= 0) {
-                        rect.origin.x = origin.x + currentWidthPositive
-                        rect.size.width = stackValue - origin.x
+                    let stackValue = Float(data.stackSeries_scaledValues[i][index].y)
+                    if (stackValue - data.origin.x >= 0) {
+                        rect.origin.x = data.origin.x + currentWidthPositive
+                        rect.size.width = stackValue - data.origin.x
                         currentWidthPositive += stackValue
                     }
                     else {
-                        rect.origin.x = origin.x - currentWidthNegative - stackValue
-                        rect.size.width = stackValue - origin.x
+                        rect.origin.x = data.origin.x - currentWidthNegative - stackValue
+                        rect.size.width = stackValue - data.origin.x
                         currentWidthNegative += stackValue
                     }
                     renderer.drawSolidRect(rect,

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -178,19 +178,12 @@ extension BarGraph: HasGraphLayout {
 
             // scale points to be plotted according to plot size
             let scaleYInv: Float = 1.0/scaleY
-            series_scaledValues.removeAll();
-            for j in 0..<series.count {
-                let scaledPair = Pair<T,U>(series[j].x,
-                                           series[j].y*U(scaleYInv) + U(origin.y))
-                series_scaledValues.append(scaledPair)
+            series_scaledValues = series.values.map { pt in
+                Pair<T,U>(pt.x, pt.y*U(scaleYInv) + U(origin.y))
             }
-            stackSeries_scaledValues.removeAll()
-            for index in 0..<stackSeries.count {
-                stackSeries_scaledValues.append([])
-                for j in 0..<(stackSeries[index]).count {
-                    let scaledPair = Pair<T,U>((stackSeries[index])[j].x,
-                                               ((stackSeries[index])[j].y)*U(scaleYInv)+U(origin.y))
-                    stackSeries_scaledValues[index].append(scaledPair)
+            stackSeries_scaledValues = stackSeries.map { series in
+                series.values.map { pt in
+                    Pair<T,U>(pt.x, (pt.y)*U(scaleYInv)+U(origin.y))
                 }
             }
         }
@@ -263,19 +256,12 @@ extension BarGraph: HasGraphLayout {
 
             // scale points to be plotted according to plot size
             let scaleXInv: Float = 1.0/scaleX
-            series_scaledValues.removeAll();
-            for j in 0..<series.count {
-                let scaledPair = Pair<T,U>(series[j].x,
-                                           series[j].y*U(scaleXInv)+U(origin.x))
-                series_scaledValues.append(scaledPair)
+            series_scaledValues = series.values.map { pt in
+                Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(origin.x))
             }
-            stackSeries_scaledValues.removeAll()
-            for index in 0..<stackSeries.count {
-                stackSeries_scaledValues.append([])
-                for j in 0..<(stackSeries[index]).count {
-                    let scaledPair = Pair<T,U>((stackSeries[index])[j].x,
-                                                (stackSeries[index])[j].y*U(scaleXInv)+U(origin.x))
-                    stackSeries_scaledValues[index].append(scaledPair)
+            stackSeries_scaledValues = stackSeries.map { series in
+                series.values.map { pt in
+                    Pair<T,U>(pt.x, pt.y*U(scaleXInv)+U(origin.x))
                 }
             }
         }

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -94,7 +94,7 @@ extension BarGraph: HasGraphLayout {
     }
     
     // functions implementing plotting logic
-    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers?) {
         
         var results = DrawingData()
         var markers = PlotMarkers()
@@ -292,7 +292,7 @@ extension BarGraph: HasGraphLayout {
     }
 
     //functions to draw the plot
-    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, size: Size, renderer: Renderer) {
         if (graphOrientation == .vertical) {
             for index in 0..<data.series_scaledValues.count {
                 var currentHeightPositive: Float = 0

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -92,15 +92,22 @@ extension BarGraph: HasGraphLayout {
         return legendSeries
     }
     
-    // functions implementing plotting logic
-    public func calculateScaleAndMarkerLocations(markers: inout PlotMarkers, size: Size, renderer: Renderer) {
+    public struct DrawingData {
+        
+    }
     
+    // functions implementing plotting logic
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+        
+        var results = DrawingData()
+        var markers = PlotMarkers()
+        
         var maximumY: U = U(0)
         var minimumY: U = U(0)
         var maximumX: U = U(0)
         var minimumX: U = U(0)
 
-        guard series.count > 0 else { return }
+        guard series.count > 0 else { return (results, markers) }
         if (graphOrientation == .vertical) {
             barWidth = Int(round(size.width/Float(series.count)))
             maximumY = maxY(points: series.values)
@@ -265,11 +272,11 @@ extension BarGraph: HasGraphLayout {
                 }
             }
         }
-
+        return (results, markers)
     }
 
     //functions to draw the plot
-    public func drawData(markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
         if (graphOrientation == .vertical) {
             for index in 0..<series.count {
                 var currentHeightPositive: Float = 0

--- a/Sources/SwiftPlot/BarChart.swift
+++ b/Sources/SwiftPlot/BarChart.swift
@@ -1,12 +1,15 @@
 import Foundation
 
+fileprivate let MAX_DIV: Float = 50
+
 // class defining a barGraph and all it's logic
 public struct BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
 
-    let MAX_DIV: Float = 50
-
     public var layout = GraphLayout()
-    
+    // Data.
+    var series = Series<T,U>()
+    var stackSeries = [Series<T,U>]()
+    // BarGraph layout properties.
     public enum GraphOrientation {
         case vertical
         case horizontal
@@ -14,38 +17,29 @@ public struct BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     public var graphOrientation: GraphOrientation = .vertical
     public var space: Int = 20
     
-    var series = Series<T,U>()
-    var stackSeries = [Series<T,U>]()
-    
     public init(enableGrid: Bool = false){
         self.enableGrid = enableGrid
     }
-    
-    public var enableGrid: Bool {
-        get { layout.enablePrimaryAxisGrid }
-        set { layout.enablePrimaryAxisGrid = newValue }
-    }
-    
+}
+
+// Setting data.
+
+extension BarGraph {
+
     public mutating func addSeries(_ s: Series<T,U>){
         series = s
     }
+    
     public mutating func addStackSeries(_ s: Series<T,U>) {
-        if (series.count != 0 && series.count == s.count) {
-            stackSeries.append(s)
-        }
-        else {
-            print("Stack point count does not match the Series point count.")
-        }
+        precondition(series.count != 0 && series.count == s.count,
+                     "Stack point count does not match the Series point count.")
+        stackSeries.append(s)
     }
     public mutating func addStackSeries(_ x: [U],
                                label: String,
                                color: Color = .lightBlue,
                                hatchPattern: BarGraphSeriesOptions.Hatching = .none) {
-        var values = [Pair<T,U>]()
-        for i in 0..<x.count {
-            values.append(Pair<T,U>(series.values[i].x, x[i]))
-        }
-        let s = Series<T,U>(values: values,
+        let s = Series<T,U>(values: (0..<x.count).map { i in Pair(series.values[i].x, x[i]) },
                             label: label,
                             color: color,
                             hatchPattern: hatchPattern)
@@ -75,7 +69,18 @@ public struct BarGraph<T:LosslessStringConvertible,U:FloatConvertible>: Plot {
     }
 }
 
-// extension containing drawing logic
+// Layout properties.
+
+extension BarGraph {
+    
+    public var enableGrid: Bool {
+        get { layout.enablePrimaryAxisGrid }
+        set { layout.enablePrimaryAxisGrid = newValue }
+    }
+}
+
+// Layout and drawing of data.
+
 extension BarGraph: HasGraphLayout {
     
     public var legendLabels: [(String, LegendIcon)] {

--- a/Sources/SwiftPlot/BarGraphSeriesOptions.swift
+++ b/Sources/SwiftPlot/BarGraphSeriesOptions.swift
@@ -1,4 +1,4 @@
-public class BarGraphSeriesOptions {
+public struct BarGraphSeriesOptions {
     public enum Hatching: Int, CaseIterable{
         case none = 0
         case forwardSlash = 1

--- a/Sources/SwiftPlot/GraphLayout.swift
+++ b/Sources/SwiftPlot/GraphLayout.swift
@@ -205,12 +205,8 @@ public struct GraphLayout {
     func drawForeground(results: Results, renderer: Renderer) {
         drawTitle(results: results, renderer: renderer)
         drawLabels(results: results, renderer: renderer)
-<<<<<<< HEAD
-        drawLegend(legendLabels, results: results, renderer: renderer)
-        drawAnnotations(renderer: renderer)
-=======
         drawLegend(results.legendLabels, results: results, renderer: renderer)
->>>>>>> 57cda29... Move LegendLabels in to results, so now we don't mutate the layout object when drawing! Woo!
+        drawAnnotations(renderer: renderer)
     }
     
     private func drawTitle(results: Results, renderer: Renderer) {
@@ -480,7 +476,7 @@ extension Plot where Self: HasGraphLayout {
         layout.drawForeground(results: results, renderer: renderer)
     }
 
-    public func addAnnotation(annotation: Annotation) {
+    public mutating func addAnnotation(annotation: Annotation) {
         layout.annotations.append(annotation)
     }
 }

--- a/Sources/SwiftPlot/GraphLayout.swift
+++ b/Sources/SwiftPlot/GraphLayout.swift
@@ -377,7 +377,7 @@ public struct GraphLayout {
     }
 }
 
-public protocol HasGraphLayout: AnyObject {
+public protocol HasGraphLayout {
     
     var layout: GraphLayout { get set }
     
@@ -458,7 +458,8 @@ extension HasGraphLayout {
 
 extension Plot where Self: HasGraphLayout {
     
-    public func drawGraph(size: Size, renderer: Renderer) {
+    // TODO: Stop this being mutating.
+    public mutating func drawGraph(size: Size, renderer: Renderer) {
         layout.legendLabels = self.legendLabels
         layout.plotSize = size
         let (drawingData, results) = layout.layout(renderer: renderer) { size in

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -136,9 +136,16 @@ extension Histogram: HasGraphLayout {
         legendSeries.insert((histogramSeries.label, .square(histogramSeries.color)), at: 0)
         return legendSeries
     }
+    
+    public struct DrawingData {
+        
+    }
 
     // functions implementing plotting logic
-    public func calculateScaleAndMarkerLocations(markers: inout PlotMarkers, size: Size, renderer: Renderer) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+        
+        var results = DrawingData()
+        var markers = PlotMarkers()
         
         var maximumY = Float(histogramSeries.maximumFrequency)
         let minimumY = Float(0)
@@ -275,10 +282,11 @@ extension Histogram: HasGraphLayout {
                 histogramStackSeries[index].scaledBinFrequency.append(frequency*scaleYInv + origin.y)
             }
         }
+        
+        return (results, markers)
     }
-    
-    /// Draw with rectangles if `histogramType` is `.bar` or with lines if `histogramType` is `.step`
-    public func drawData(markers: PlotMarkers, size: Size, renderer: Renderer) {
+    //functions to draw the plot
+    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
         let binCount = histogramSeries.bins
         let allSeries = [histogramSeries] + histogramStackSeries
         switch histogramSeries.histogramSeriesOptions.histogramType {

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -142,7 +142,7 @@ extension Histogram: HasGraphLayout {
     }
 
     // functions implementing plotting logic
-    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers?) {
         
         var results = DrawingData()
         var markers = PlotMarkers()
@@ -286,7 +286,7 @@ extension Histogram: HasGraphLayout {
         return (results, markers)
     }
     //functions to draw the plot
-    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, size: Size, renderer: Renderer) {
         let binCount = histogramSeries.bins
         let allSeries = [histogramSeries] + histogramStackSeries
         switch histogramSeries.histogramSeriesOptions.histogramType {

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -1,29 +1,28 @@
 import Foundation
 
+fileprivate let MAX_DIV: Float = 50
+
 // class defining a barGraph and all it's logic
 public struct Histogram<T:FloatConvertible>: Plot {
 
-    let MAX_DIV: Float = 50
-
     public var layout = GraphLayout()
-
-    public var strokeWidth: Float = 2
-    
+    // Data.
     var histogramSeries = HistogramSeries<T>()
     var histogramStackSeries = [HistogramSeries<T>]()
+    // Histogram layout properties.
+    public var strokeWidth: Float = 2
     var isNormalized = false
-    
     
     public init(isNormalized: Bool = false,
                 enableGrid: Bool = false){
         self.isNormalized = isNormalized
         self.enableGrid = enableGrid
     }
-    
-    public var enableGrid: Bool {
-        get { layout.enablePrimaryAxisGrid }
-        set { layout.enablePrimaryAxisGrid = newValue }
-    }
+}
+
+// Setting data.
+
+extension Histogram {
     
     public mutating func addSeries(_ s: HistogramSeries<T>){
         histogramSeries = s
@@ -48,6 +47,19 @@ public struct Histogram<T:FloatConvertible>: Plot {
                                                         color: color,
                                                         histogramType: histogramSeries.histogramSeriesOptions.histogramType))
     }
+}
+
+// Layout properties.
+
+extension Histogram {
+    
+    public var enableGrid: Bool {
+        get { layout.enablePrimaryAxisGrid }
+        set { layout.enablePrimaryAxisGrid = newValue }
+    }
+}
+
+extension Histogram {
     func calculateSeriesData(data: [T],
                              bins: Int,
                              label: String,

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -80,7 +80,7 @@ extension Histogram: HasGraphLayout {
         var stack_scaledBinFrequency = [[Float]]()
         
         var barWidth: Float = 0
-        var xMargin: Float = 5
+        let xMargin: Float = 5
         var origin = zeroPoint
     }
 
@@ -237,8 +237,7 @@ extension Histogram: HasGraphLayout {
                 var currentHeight: Float = 0.0
                 for (series, index) in zip(allSeries, frequencySlices.indices) {
                     let height = frequencySlices[index].removeFirst()
-                    let rect = Rect(origin: Point(x, currentHeight), size: Size(width: data.barWidth, height:
-                        height))
+                    let rect = Rect(origin: Point(x, currentHeight), size: Size(width: data.barWidth, height: height))
                     renderer.drawSolidRect(rect, fillColor: allSeriesInfo[index].color,
                                            hatchPattern: .none)
                     currentHeight += height

--- a/Sources/SwiftPlot/Histogram.swift
+++ b/Sources/SwiftPlot/Histogram.swift
@@ -11,7 +11,7 @@ public struct Histogram<T:FloatConvertible>: Plot {
     var histogramStackSeries = [HistogramSeries<T>]()
     // Histogram layout properties.
     public var strokeWidth: Float = 2
-    var isNormalized = false
+    public var isNormalized = false
     
     public init(isNormalized: Bool = false,
                 enableGrid: Bool = false){

--- a/Sources/SwiftPlot/HistogramSeries.swift
+++ b/Sources/SwiftPlot/HistogramSeries.swift
@@ -1,32 +1,19 @@
-public class HistogramSeries<T> {
+public struct HistogramSeries<T> where T: Comparable {
     public var data = [T]()
     public var bins: Int = 0
-
-    public var minimumX: T?
-    public var maximumX: T?
-    public var binInterval: T?
     public var label = ""
     public var color: Color = .lightBlue
     public var histogramSeriesOptions = HistogramSeriesOptions()
-    public var isNormalized = false
     public init() {}
     public init(data: [T],
                 bins: Int,
-                isNormalized: Bool,
                 label: String,
                 color: Color,
-                histogramType: HistogramSeriesOptions.HistogramType,
-                minimumX: T,
-                maximumX: T,
-                binInterval: T) {
-        self.data = data
+                histogramType: HistogramSeriesOptions.HistogramType) {
+        self.data = data.sorted()
         self.bins = bins
-        self.isNormalized = isNormalized
         self.label = label
         self.color = color
         histogramSeriesOptions.histogramType = histogramType
-        self.minimumX = minimumX
-        self.maximumX = maximumX
-        self.binInterval = binInterval
     }
 }

--- a/Sources/SwiftPlot/HistogramSeries.swift
+++ b/Sources/SwiftPlot/HistogramSeries.swift
@@ -1,9 +1,7 @@
 public class HistogramSeries<T> {
     public var data = [T]()
     public var bins: Int = 0
-    public var binFrequency = [Float]()
-    public var scaledBinFrequency = [Float]()
-    public var maximumFrequency: Float = 0
+
     public var minimumX: T?
     public var maximumX: T?
     public var binInterval: T?
@@ -18,8 +16,6 @@ public class HistogramSeries<T> {
                 label: String,
                 color: Color,
                 histogramType: HistogramSeriesOptions.HistogramType,
-                binFrequency: [Float],
-                maximumFrequency: Float,
                 minimumX: T,
                 maximumX: T,
                 binInterval: T) {
@@ -29,8 +25,6 @@ public class HistogramSeries<T> {
         self.label = label
         self.color = color
         histogramSeriesOptions.histogramType = histogramType
-        self.binFrequency = binFrequency
-        self.maximumFrequency = maximumFrequency
         self.minimumX = minimumX
         self.maximumX = maximumX
         self.binInterval = binInterval

--- a/Sources/SwiftPlot/HistogramSeriesOptions.swift
+++ b/Sources/SwiftPlot/HistogramSeriesOptions.swift
@@ -1,4 +1,4 @@
-public class HistogramSeriesOptions {
+public struct HistogramSeriesOptions {
     public enum HistogramType: CaseIterable{
         case bar
         case step

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -121,7 +121,7 @@ extension LineGraph: HasGraphLayout {
     }
 
     // functions implementing plotting logic
-    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers?) {
         var results = DrawingData()
         var markers = PlotMarkers()
         guard !primaryAxis.series.isEmpty, !primaryAxis.series[0].values.isEmpty else { return (results, markers) }
@@ -429,7 +429,7 @@ extension LineGraph: HasGraphLayout {
     }
 
     //functions to draw the plot
-    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, size: Size, renderer: Renderer) {
         for i in 0..<primaryAxis.series.count {
             let s = primaryAxis.series[i]
             let scaledValues = primaryAxis_series_scaledValues[i]

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -12,30 +12,23 @@ public struct LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
     // Linegraph layout properties.
     public var plotLineThickness: Float = 1.5
     
-    public init(points : [Pair<T,U>],
-                enablePrimaryAxisGrid: Bool = false,
-                enableSecondaryAxisGrid: Bool = false){
-        self.init(enablePrimaryAxisGrid: enablePrimaryAxisGrid, enableSecondaryAxisGrid: enableSecondaryAxisGrid)
-
-        let s = Series<T,U>(values: points,label: "Plot")
-        primaryAxis.series.append(s)
-    }
-
     public init(enablePrimaryAxisGrid: Bool = false,
                 enableSecondaryAxisGrid: Bool = false){
         self.enablePrimaryAxisGrid = enablePrimaryAxisGrid
         self.enableSecondaryAxisGrid = enableSecondaryAxisGrid
     }
     
-    public var enablePrimaryAxisGrid: Bool {
-        get { layout.enablePrimaryAxisGrid }
-        set { layout.enablePrimaryAxisGrid = newValue }
+    public init(points : [Pair<T,U>],
+                enablePrimaryAxisGrid: Bool = false,
+                enableSecondaryAxisGrid: Bool = false){
+        self.init(enablePrimaryAxisGrid: enablePrimaryAxisGrid, enableSecondaryAxisGrid: enableSecondaryAxisGrid)
+        primaryAxis.series.append(Series(values: points, label: "Plot"))
     }
-    
-    public var enableSecondaryAxisGrid: Bool {
-        get { layout.enableSecondaryAxisGrid }
-        set { layout.enableSecondaryAxisGrid = newValue }
-    }
+}
+
+// Setting data.
+
+extension LineGraph {
 
     // functions to add series
     public mutating func addSeries(_ s: Series<T,U>,
@@ -102,7 +95,23 @@ public struct LineGraph<T:FloatConvertible,U:FloatConvertible>: Plot {
     }
 }
 
-// extension containing drawing logic
+// Layout properties.
+
+extension LineGraph {
+    
+    public var enablePrimaryAxisGrid: Bool {
+        get { layout.enablePrimaryAxisGrid }
+        set { layout.enablePrimaryAxisGrid = newValue }
+    }
+    
+    public var enableSecondaryAxisGrid: Bool {
+        get { layout.enableSecondaryAxisGrid }
+        set { layout.enableSecondaryAxisGrid = newValue }
+    }
+}
+
+// Layout and drawing of data.
+
 extension LineGraph: HasGraphLayout {
 
     public var legendLabels: [(String, LegendIcon)] {

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -115,10 +115,16 @@ extension LineGraph: HasGraphLayout {
         }
         return allSeries.map { ($0.label, .square($0.color)) }
     }
+    
+    public struct DrawingData {
+        
+    }
 
     // functions implementing plotting logic
-    public func calculateScaleAndMarkerLocations(markers: inout PlotMarkers, size: Size, renderer: Renderer) {
-        guard !primaryAxis.series.isEmpty, !primaryAxis.series[0].values.isEmpty else { return }
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+        var results = DrawingData()
+        var markers = PlotMarkers()
+        guard !primaryAxis.series.isEmpty, !primaryAxis.series[0].values.isEmpty else { return (results, markers) }
         var maximumXPrimary: T = maxX(points: primaryAxis.series[0].values)
         var maximumYPrimary: U = maxY(points: primaryAxis.series[0].values)
         var minimumXPrimary: T = minX(points: primaryAxis.series[0].values)
@@ -418,10 +424,12 @@ extension LineGraph: HasGraphLayout {
                 }
             }
         }
+        
+        return (results, markers)
     }
 
     //functions to draw the plot
-    public func drawData(markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
         for i in 0..<primaryAxis.series.count {
             let s = primaryAxis.series[i]
             let scaledValues = primaryAxis_series_scaledValues[i]

--- a/Sources/SwiftPlot/LineChart.swift
+++ b/Sources/SwiftPlot/LineChart.swift
@@ -342,15 +342,15 @@ extension LineGraph: HasGraphLayout {
         // scale points to be plotted according to plot size
         let scaleXInvPrimary: Float = 1.0/primaryAxis.scaleX;
         let scaleYInvPrimary: Float = 1.0/primaryAxis.scaleY
-        primaryAxis_series_scaledValues = []
-        for i in 0..<primaryAxis.series.count {
-            primaryAxis_series_scaledValues.append([])
-            for j in 0..<primaryAxis.series[i].count {
-                let scaledPair = Pair<T,U>(((primaryAxis.series[i])[j].x)*T(scaleXInvPrimary) + T(originPrimary.x),
-                                           ((primaryAxis.series[i])[j].y)*U(scaleYInvPrimary) + U(originPrimary.y))
-                if Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height {
-                    primaryAxis_series_scaledValues[i].append(scaledPair)
+        primaryAxis_series_scaledValues = primaryAxis.series.map { series in
+            series.values.compactMap { value in
+                let scaledPair = Pair<T,U>(value.x * T(scaleXInvPrimary) + T(originPrimary.x),
+                                           value.y * U(scaleYInvPrimary) + U(originPrimary.y))
+                guard Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width
+                    && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height else {
+                    return nil
                 }
+                return scaledPair
             }
         }
 
@@ -405,17 +405,16 @@ extension LineGraph: HasGraphLayout {
 
 
             // scale points to be plotted according to plot size
-            secondaryAxis_series_scaledValues = []
             let scaleYInvSecondary: Float = 1.0/secondaryAxis!.scaleY
-            for i in 0..<secondaryAxis!.series.count {
-                // let pairs = secondaryAxis!.series[i].pairs
-                secondaryAxis_series_scaledValues.append([])
-                for j in 0..<secondaryAxis!.series[i].count {
-                    let scaledPair = Pair<T,U>(((secondaryAxis!.series[i])[j].x)*T(scaleXInvPrimary) + T(originPrimary.x),
-                                               ((secondaryAxis!.series[i])[j].y)*U(scaleYInvSecondary) + U(originSecondary!.y))
-                    if (Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height) {
-                        secondaryAxis_series_scaledValues[i].append(scaledPair)
+            secondaryAxis_series_scaledValues = secondaryAxis!.series.map { series in
+                series.values.compactMap { value in
+                    let scaledPair = Pair<T,U>(value.x * T(scaleXInvPrimary) + T(originPrimary.x),
+                                               value.y * U(scaleYInvSecondary) + U(originSecondary!.y))
+                    guard Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width
+                        && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height else {
+                        return nil
                     }
+                    return scaledPair
                 }
             }
         }

--- a/Sources/SwiftPlot/Plot.swift
+++ b/Sources/SwiftPlot/Plot.swift
@@ -7,20 +7,20 @@ public protocol Plot {
     ///     - renderer: The renderer. The plot should draw between
     ///       `(0...size.width)` on the X-axis and
     ///       `(0...size.height)` on the Y-axis.
-    func drawGraph(size: Size, renderer: Renderer)
+    mutating func drawGraph(size: Size, renderer: Renderer)
 }
 
 extension Plot {
    
     /// Draws to the given renderer in-memory at a default size.
-    public func drawGraph(renderer: Renderer) {
+    public mutating func drawGraph(renderer: Renderer) {
         drawGraph(size: Size(width: 1000, height: 660),
                   renderer: renderer)
     }
     
     /// Draws and saves the graph to the named file.
     /// - note: This function changes the `imageSize` of the `Renderer` it is given.
-    public func drawGraphAndOutput(size: Size = Size(width: 1000, height: 660),
+    public mutating func drawGraphAndOutput(size: Size = Size(width: 1000, height: 660),
                                    fileName name: String = "swiftplot_graph", renderer: Renderer) throws {
         renderer.imageSize = size
         drawGraph(size: size, renderer: renderer)
@@ -29,7 +29,7 @@ extension Plot {
 
     /// Saves the already-drawn graph to the named file.
     /// - note: This function changes the `imageSize` of the `Renderer` it is given.
-    public func drawGraphOutput(size: Size = Size(width: 1000, height: 660),
+    public mutating func drawGraphOutput(size: Size = Size(width: 1000, height: 660),
                                 fileName name: String = "swiftplot_graph", renderer: Renderer) throws {
         renderer.imageSize = size
         try renderer.drawOutput(fileName: name)

--- a/Sources/SwiftPlot/Plot.swift
+++ b/Sources/SwiftPlot/Plot.swift
@@ -7,20 +7,20 @@ public protocol Plot {
     ///     - renderer: The renderer. The plot should draw between
     ///       `(0...size.width)` on the X-axis and
     ///       `(0...size.height)` on the Y-axis.
-    mutating func drawGraph(size: Size, renderer: Renderer)
+    func drawGraph(size: Size, renderer: Renderer)
 }
 
 extension Plot {
    
     /// Draws to the given renderer in-memory at a default size.
-    public mutating func drawGraph(renderer: Renderer) {
+    public func drawGraph(renderer: Renderer) {
         drawGraph(size: Size(width: 1000, height: 660),
                   renderer: renderer)
     }
     
     /// Draws and saves the graph to the named file.
     /// - note: This function changes the `imageSize` of the `Renderer` it is given.
-    public mutating func drawGraphAndOutput(size: Size = Size(width: 1000, height: 660),
+    public func drawGraphAndOutput(size: Size = Size(width: 1000, height: 660),
                                    fileName name: String = "swiftplot_graph", renderer: Renderer) throws {
         renderer.imageSize = size
         drawGraph(size: size, renderer: renderer)
@@ -29,7 +29,7 @@ extension Plot {
 
     /// Saves the already-drawn graph to the named file.
     /// - note: This function changes the `imageSize` of the `Renderer` it is given.
-    public mutating func drawGraphOutput(size: Size = Size(width: 1000, height: 660),
+    public func drawGraphOutput(size: Size = Size(width: 1000, height: 660),
                                 fileName name: String = "swiftplot_graph", renderer: Renderer) throws {
         renderer.imageSize = size
         try renderer.drawOutput(fileName: name)

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -14,6 +14,8 @@ public class ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
 
     var series = [Series<T,U>]()
     var series_scaledValues = [[Pair<T,U>]]()
+    var series_maxY: U? = nil
+    var series_minY: U? = nil
     var scaleX: Float = 1
     var scaleY: Float = 1
 
@@ -297,11 +299,11 @@ extension ScatterPlot: HasGraphLayout {
     //functions to draw the plot
     public func drawData(markers: PlotMarkers, size: Size, renderer: Renderer) {
         for seriesIndex in 0..<series.count {
-            var s = series[seriesIndex]
+            let s = series[seriesIndex]
             let scaledValues = series_scaledValues[seriesIndex]
-            s.maxY = maxY(points: scaledValues)
-            s.minY = minY(points: scaledValues)
-            let seriesYRangeInverse: Float = 1.0/Float(s.maxY!-s.minY!)
+            series_maxY = maxY(points: scaledValues)
+            series_minY = minY(points: scaledValues)
+            let seriesYRangeInverse: Float = 1.0/Float(series_maxY!-series_minY!)
 
             for value in scaledValues {
                 let p = Point(Float(value.x),Float(value.y))
@@ -309,7 +311,7 @@ extension ScatterPlot: HasGraphLayout {
                 if let startColor = s.startColor, let endColor = s.endColor {
                     color = lerp(startColor: startColor,
                                  endColor: endColor,
-                                 Float(value.y-s.minY!)*seriesYRangeInverse)
+                                 Float(value.y-series_minY!)*seriesYRangeInverse)
                 } else {
                     color = s.color
                 }

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -118,9 +118,16 @@ extension ScatterPlot: HasGraphLayout {
             ($0.label, .shape($0.scatterPlotSeriesOptions.scatterPattern, $0.startColor ?? $0.color))
         }
     }
+    
+    public struct DrawingData {
+        
+    }
 
     // functions implementing plotting logic
-    public func calculateScaleAndMarkerLocations(markers: inout PlotMarkers, size: Size, renderer: Renderer) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+        
+        var results = DrawingData()
+        var markers = PlotMarkers()
         
         var maximumX: T = maxX(points: series[0].values)
         var maximumY: U = maxY(points: series[0].values)
@@ -294,10 +301,12 @@ extension ScatterPlot: HasGraphLayout {
                 return scaledPair
             }
         }
+        
+        return (results, markers)
     }
 
     //functions to draw the plot
-    public func drawData(markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
         for seriesIndex in 0..<series.count {
             let s = series[seriesIndex]
             let scaledValues = series_scaledValues[seriesIndex]

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -124,7 +124,7 @@ extension ScatterPlot: HasGraphLayout {
     }
 
     // functions implementing plotting logic
-    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers) {
+    public func layoutData(size: Size, renderer: Renderer) -> (DrawingData, PlotMarkers?) {
         
         var results = DrawingData()
         var markers = PlotMarkers()
@@ -306,7 +306,7 @@ extension ScatterPlot: HasGraphLayout {
     }
 
     //functions to draw the plot
-    public func drawData(_ data: DrawingData, markers: PlotMarkers, size: Size, renderer: Renderer) {
+    public func drawData(_ data: DrawingData, size: Size, renderer: Renderer) {
         for seriesIndex in 0..<series.count {
             let s = series[seriesIndex]
             let scaledValues = series_scaledValues[seriesIndex]

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -23,11 +23,11 @@ public struct ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
         let s = Series<T,U>(values: p,label: "Plot")
         series.append(s)
     }
+}
 
-    public var enableGrid: Bool {
-        get { layout.enablePrimaryAxisGrid }
-        set { layout.enablePrimaryAxisGrid = newValue }
-    }
+// Setting data.
+
+extension ScatterPlot {
 
     // functions to add series
     public mutating func addSeries(_ s: Series<T,U>){
@@ -104,7 +104,18 @@ public struct ScatterPlot<T:FloatConvertible,U:FloatConvertible>: Plot {
     }
 }
 
-// extension containing drawing logic
+// Layout properties.
+
+extension ScatterPlot {
+    
+    public var enableGrid: Bool {
+        get { layout.enablePrimaryAxisGrid }
+        set { layout.enablePrimaryAxisGrid = newValue }
+    }
+}
+
+// Layout and drawing of data.
+
 extension ScatterPlot: HasGraphLayout {
 
     public var legendLabels: [(String, LegendIcon)] {

--- a/Sources/SwiftPlot/ScatterChart.swift
+++ b/Sources/SwiftPlot/ScatterChart.swift
@@ -283,15 +283,15 @@ extension ScatterPlot: HasGraphLayout {
         // scale points to be plotted according to plot size
         let scaleXInv: Float = 1.0/scaleX;
         let scaleYInv: Float = 1.0/scaleY
-        series_scaledValues = []
-        for i in 0..<series.count {
-            series_scaledValues.append([])
-            for j in 0..<series[i].count {
-                let scaledPair = Pair<T,U>(((series[i])[j].x)*T(scaleXInv) + T(origin.x),
-                                           ((series[i])[j].y)*U(scaleYInv) + U(origin.y))
-                if (Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height) {
-                    series_scaledValues[i].append(scaledPair)
+        series_scaledValues = series.map { series in
+            series.values.compactMap { value in
+                let scaledPair = Pair<T,U>(value.x * T(scaleXInv) + T(origin.x),
+                                           value.y * U(scaleYInv) + U(origin.y))
+                guard Float(scaledPair.x) >= 0.0 && Float(scaledPair.x) <= size.width
+                    && Float(scaledPair.y) >= 0.0 && Float(scaledPair.y) <= size.height else {
+                    return nil
                 }
+                return scaledPair
             }
         }
     }

--- a/Sources/SwiftPlot/ScatterPlotSeriesOptions.swift
+++ b/Sources/SwiftPlot/ScatterPlotSeriesOptions.swift
@@ -1,4 +1,4 @@
-public class ScatterPlotSeriesOptions {
+public struct ScatterPlotSeriesOptions {
     public enum ScatterPattern{
         case circle
         case square

--- a/Sources/SwiftPlot/Series.swift
+++ b/Sources/SwiftPlot/Series.swift
@@ -3,8 +3,6 @@ public struct Series<T,U> {
     public var barGraphSeriesOptions = BarGraphSeriesOptions()
     public var scatterPlotSeriesOptions = ScatterPlotSeriesOptions()
     public var values = [Pair<T,U>]()
-    public var maxY: U? = nil
-    public var minY: U? = nil
     public var label = "Plot"
     public var color : Color = .blue
     public var startColor: Color? = nil

--- a/Sources/SwiftPlot/Series.swift
+++ b/Sources/SwiftPlot/Series.swift
@@ -3,7 +3,6 @@ public struct Series<T,U> {
     public var barGraphSeriesOptions = BarGraphSeriesOptions()
     public var scatterPlotSeriesOptions = ScatterPlotSeriesOptions()
     public var values = [Pair<T,U>]()
-    public var scaledValues = [Pair<T,U>]()
     public var maxY: U? = nil
     public var minY: U? = nil
     public var label = "Plot"

--- a/Sources/SwiftPlot/SubPlot.swift
+++ b/Sources/SwiftPlot/SubPlot.swift
@@ -1,4 +1,4 @@
-public class SubPlot: Plot {
+public struct SubPlot: Plot {
 
     public enum StackPattern {
         case vertical

--- a/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
+++ b/Tests/SwiftPlotTests/AGGRenderer/agg-png-output.swift
@@ -12,7 +12,7 @@ extension AGGRendererTests {
     
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .cross)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/Annotation/annotation-arrow.swift
+++ b/Tests/SwiftPlotTests/Annotation/annotation-arrow.swift
@@ -15,7 +15,7 @@ extension AnnotationTests {
 
     let fileName = "_31_arrow_annotation"
 
-    let lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
     lineGraph.addFunction(sin, minX: -5.0, maxX: 5.0, label: "sin(x)", color: .lightBlue)
     lineGraph.plotTitle.title = "FUNCTION"
     lineGraph.plotLabel.xLabel = "X-AXIS"

--- a/Tests/SwiftPlotTests/Annotation/annotation-text-bounding-box.swift
+++ b/Tests/SwiftPlotTests/Annotation/annotation-text-bounding-box.swift
@@ -17,7 +17,7 @@ extension AnnotationTests {
     let x:[Float] = [10,100,263,489]
     let y:[Float] = [10,120,500,800]
 
-    let lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
     lineGraph.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph.plotTitle.title = "SINGLE SERIES"
     lineGraph.plotLabel.xLabel = "X-AXIS"

--- a/Tests/SwiftPlotTests/Annotation/annotation-text.swift
+++ b/Tests/SwiftPlotTests/Annotation/annotation-text.swift
@@ -17,7 +17,7 @@ extension AnnotationTests {
     let x:[Float] = [10,100,263,489]
     let y:[Float] = [10,120,500,800]
 
-    let lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float, Float>(enablePrimaryAxisGrid: true)
     lineGraph.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph.plotTitle.title = "SINGLE SERIES"
     lineGraph.plotLabel.xLabel = "X-AXIS"

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-backwardslash.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-backwardslash.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
     
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .backwardSlash)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-cross.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-cross.swift
@@ -19,7 +19,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
     
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .cross)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-filledcircle.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-filledcircle.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
         
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .filledCircle)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-forwardsslash.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-forwardsslash.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
         
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .forwardSlash)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-grid.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-grid.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
     
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .grid)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-hollowcircle.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-hollowcircle.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
     
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .hollowCircle)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-horizontal.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-horizontal.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .horizontal)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-hatched-vertical.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-hatched-vertical.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .vertical)
     barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-orientation-horizontal.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-orientation-horizontal.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, graphOrientation: .horizontal)
     barGraph.plotTitle = PlotTitle("BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/BarChart/barchart-stacked-horizontal.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-stacked-horizontal.swift
@@ -18,7 +18,7 @@ extension BarchartTests {
     let y:[Float] = [320,-100,420,500]
     let y1:[Float] = [100,100,220,245]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange, graphOrientation: .horizontal)
     barGraph.addStackSeries(y1, label: "Plot 2", color: .blue)
     barGraph.plotTitle = PlotTitle("BAR CHART")

--- a/Tests/SwiftPlotTests/BarChart/barchart-stacked-vertical.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart-stacked-vertical.swift
@@ -18,7 +18,7 @@ extension BarchartTests {
     let y:[Float] = [320,-100,420,500]
     let y1:[Float] = [100,100,220,245]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange)
     barGraph.addStackSeries(y1, label: "Plot 2", color: .blue)
     barGraph.plotTitle = PlotTitle("BAR CHART")

--- a/Tests/SwiftPlotTests/BarChart/barchart.swift
+++ b/Tests/SwiftPlotTests/BarChart/barchart.swift
@@ -17,7 +17,7 @@ extension BarchartTests {
     let x:[String] = ["2008","2009","2010","2011"]
     let y:[Float] = [320,-100,420,500]
 
-    let barGraph = BarGraph<String,Float>(enableGrid: true)
+    var barGraph = BarGraph<String,Float>(enableGrid: true)
     barGraph.addSeries(x, y, label: "Plot 1", color: .orange)
     barGraph.plotTitle = PlotTitle("BAR CHART")
     barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/Histogram/histogram-regression-tests.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-regression-tests.swift
@@ -14,7 +14,7 @@ extension HistogramTests {
   func testHistogramStackedStepOffset() throws {
     let fileName = "_reg_57_histogram_stacked_step_offset"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: [5], bins: 10, label: "Plot 1", color: .blue, histogramType: .step)
     histogram.addStackSeries(data: [6], label: "Plot 2", color: .orange)
     histogram.plotTitle = PlotTitle("HISTOGRAM STACKED STEP")

--- a/Tests/SwiftPlotTests/Histogram/histogram-stacked-step.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-stacked-step.swift
@@ -15,7 +15,7 @@ extension HistogramTests {
     
     let fileName = "_24_histogram_stacked_step"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: histogram_stacked_step_values, bins: 50, label: "Plot 1", color: .blue, histogramType: .step)
     histogram.addStackSeries(data: histogram_stacked_step_values_2, label: "Plot 2", color: .orange)
     histogram.plotTitle = PlotTitle("HISTOGRAM STACKED STEP")

--- a/Tests/SwiftPlotTests/Histogram/histogram-stacked-step.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-stacked-step.swift
@@ -42,7 +42,7 @@ extension HistogramTests {
   func testHistogramStackedStepLineJoins() throws {
     let fileName = "_27_histogram_stacked_step_line_joins"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: [0, 13, 17, 17, 21, 25, 30, 34, 34, 38, 42, 45], bins: 49, label: "Plot 1", color: .blue, histogramType: .step)
     histogram.addStackSeries(data: [0, 6, 9, 10, 16, 18, 20, 22, 24, 24, 26, 26, 30, 33, 34, 35, 37, 38, 39, 41, 41, 42, 42, 43, 43, 45], label: "Plot 2", color: .orange)
     histogram.plotTitle = PlotTitle("HISTOGRAM STACKED STEP LINE JOINS")
@@ -73,7 +73,7 @@ extension HistogramTests {
     let data3: [Float] = x.flatMap { [Float](repeating: $0, count: Int((sin($0 + .pi) + 1)*10)) }
     let data4: [Float] = x.flatMap { [Float](repeating: $0, count: Int((cos($0 + .pi) + 1)*10)) }
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: data1, bins: 40, label: "Plot 1", color: .blue, histogramType: .step)
     histogram.addStackSeries(data: data2, label: "Plot 2", color: .orange)
     histogram.addStackSeries(data: data3, label: "Plot 3", color: .purple)

--- a/Tests/SwiftPlotTests/Histogram/histogram-stacked.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-stacked.swift
@@ -48,7 +48,7 @@ extension HistogramTests {
     let data3: [Float] = x.flatMap { [Float](repeating: $0, count: Int((sin($0 + .pi) + 1)*10)) }
     let data4: [Float] = x.flatMap { [Float](repeating: $0, count: Int((cos($0 + .pi) + 1)*10)) }
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: data1, bins: 40, label: "Plot 1", color: .blue, histogramType: .bar)
     histogram.addStackSeries(data: data2, label: "Plot 2", color: .orange)
     histogram.addStackSeries(data: data3, label: "Plot 3", color: .purple)

--- a/Tests/SwiftPlotTests/Histogram/histogram-stacked.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-stacked.swift
@@ -15,7 +15,7 @@ extension HistogramTests {
     
     let fileName = "_23_histogram_stacked"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: histogram_stacked_values, bins: 50, label: "Plot 1", color: .blue)
     histogram.addStackSeries(data: histogram_stacked_values_2, label: "Plot 2", color: .orange)
     histogram.plotTitle = PlotTitle("HISTOGRAM STACKED")

--- a/Tests/SwiftPlotTests/Histogram/histogram-step.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram-step.swift
@@ -14,7 +14,7 @@ extension HistogramTests {
     
     let fileName = "_22_histogram_step"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: histogram_step_values,
                         bins: 50,
                         label: "Plot 1",

--- a/Tests/SwiftPlotTests/Histogram/histogram.swift
+++ b/Tests/SwiftPlotTests/Histogram/histogram.swift
@@ -14,7 +14,7 @@ extension HistogramTests {
     
     let fileName = "_21_histogram"
     
-    let histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
+    var histogram = Histogram<Float>(isNormalized: false, enableGrid: true)
     histogram.addSeries(data: histogram_values, bins: 50, label: "Plot 1", color: .blue)
     histogram.plotTitle = PlotTitle("HISTOGRAM")
     histogram.plotLabel = PlotLabel(xLabel: "X", yLabel: "Frequency")

--- a/Tests/SwiftPlotTests/LineChart/linechart-functionplot.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-functionplot.swift
@@ -18,7 +18,7 @@ extension LineChartTests {
     
     let fileName = "_06_function_plot_line_chart"
     
-    let lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph.addFunction(function,
                           minX: -5.0,
                           maxX: 5.0,

--- a/Tests/SwiftPlotTests/LineChart/linechart-multiple-series.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-multiple-series.swift
@@ -19,7 +19,7 @@ extension LineChartTests {
     let x2:[Float] = [100,200,361,672]
     let y2:[Float] = [150,250,628,800]
     
-    let lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph.addSeries(x1, y1, label: "Plot 1", color: .lightBlue)
     lineGraph.addSeries(x2, y2, label: "Plot 2", color: .orange)
     lineGraph.plotTitle = PlotTitle("MULTIPLE SERIES")

--- a/Tests/SwiftPlotTests/LineChart/linechart-secondary-axis.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-secondary-axis.swift
@@ -19,7 +19,7 @@ extension LineChartTests {
     let x1:[Float] = [100,200,361,672]
     let y1:[Float] = [150,250,628,800]
     
-    let lineGraph = LineGraph<Float,Float>()
+    var lineGraph = LineGraph<Float,Float>()
     lineGraph.addSeries(x1,y1,label: "Plot 1",color: .lightBlue,axisType: .primaryAxis)
     lineGraph.addSeries(x, y, label: "Plot 2", color: .orange, axisType: .secondaryAxis)
     lineGraph.plotTitle = PlotTitle("SECONDARY AXIS")

--- a/Tests/SwiftPlotTests/LineChart/linechart-single-series.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-single-series.swift
@@ -17,7 +17,7 @@ extension LineChartTests {
     let x:[Float] = [10,100,263,489]
     let y:[Float] = [10,120,500,800]
     
-    let lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph.plotTitle = PlotTitle("SINGLE SERIES")
     lineGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/LineChart/linechart-subplot-gridstacked.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-subplot-gridstacked.swift
@@ -17,27 +17,27 @@ extension LineChartTests {
     let x:[Float] = [0,100,263,489]
     let y:[Float] = [0,320,310,170]
     
-    let subPlot = SubPlot(layout: .grid(rows: 2, columns: 2))
+    var subPlot = SubPlot(layout: .grid(rows: 2, columns: 2))
     
-    let lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph1.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph1.plotTitle = PlotTitle("PLOT 1")
     lineGraph1.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS", labelSize: 12)
     lineGraph1.markerTextSize = 10
     
-    let lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph2.addSeries(x, y, label: "Plot 2", color: .orange)
     lineGraph2.plotTitle = PlotTitle("PLOT 2")
     lineGraph2.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS", labelSize: 12)
     lineGraph2.markerTextSize = 10
     
-    let lineGraph3 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph3 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph3.addSeries(x, y, label: "Plot 3", color: .brown)
     lineGraph3.plotTitle = PlotTitle("PLOT 3")
     lineGraph3.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS", labelSize: 12)
     lineGraph3.markerTextSize = 10
     
-    let lineGraph4 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph4 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph4.addSeries(x, y, label: "Plot 4", color: .green)
     lineGraph4.plotTitle = PlotTitle("PLOT 4")
     lineGraph4.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS", labelSize: 12)

--- a/Tests/SwiftPlotTests/LineChart/linechart-subplot-h-stacked.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-subplot-h-stacked.swift
@@ -17,15 +17,15 @@ extension LineChartTests {
     let x:[Float] = [10,100,263,489]
     let y:[Float] = [10,120,500,800]
     
-    let subPlot = SubPlot(layout: .horizontal)
+    var subPlot = SubPlot(layout: .horizontal)
 
-    let lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph1.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph1.plotTitle = PlotTitle("PLOT 1")
     lineGraph1.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
     lineGraph1.plotLineThickness = 3.0
     
-    let lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph2.addSeries(x, y, label: "Plot 2", color: .orange)
     lineGraph2.plotTitle = PlotTitle("PLOT 2")
     lineGraph2.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/LineChart/linechart-subplot-v-stacked.swift
+++ b/Tests/SwiftPlotTests/LineChart/linechart-subplot-v-stacked.swift
@@ -17,15 +17,15 @@ extension LineChartTests {
     let x:[Float] = [10,100,263,489]
     let y:[Float] = [10,120,500,800]
 
-    let subPlot = SubPlot(layout: .vertical)
+    var subPlot = SubPlot(layout: .vertical)
     
-    let lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph1 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph1.addSeries(x, y, label: "Plot 1", color: .lightBlue)
     lineGraph1.plotTitle = PlotTitle("PLOT 1")
     lineGraph1.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
     lineGraph1.plotLineThickness = 3.0
     
-    let lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+    var lineGraph2 = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
     lineGraph2.addSeries(x, y, label: "Plot 2", color: .orange)
     lineGraph2.plotTitle = PlotTitle("PLOT 2")
     lineGraph2.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")

--- a/Tests/SwiftPlotTests/ScatterPlot/scatterplot.swift
+++ b/Tests/SwiftPlotTests/ScatterPlot/scatterplot.swift
@@ -14,7 +14,7 @@ extension ScatterPlotTests {
 
     let fileName = "_20_scatter_plot"
  
-    let scatterPlot = ScatterPlot<Float,Float>(enableGrid: true)
+    var scatterPlot = ScatterPlot<Float,Float>(enableGrid: true)
     scatterPlot.addSeries(scatterplot_x, scatterplot_y, label: "Plot 1", startColor: .gold, endColor: .blue, scatterPattern: .circle)
     scatterPlot.addSeries(scatterplot_x, scatterplot_y1, label: "Plot 2", color: .green, scatterPattern: .star)
     scatterPlot.plotTitle = PlotTitle("SCATTER PLOT")

--- a/Tests/SwiftPlotTests/SubPlots/subplots.swift
+++ b/Tests/SwiftPlotTests/SubPlots/subplots.swift
@@ -18,7 +18,7 @@ extension SubPlotTests {
         // ScatterPlot.
         let xValues = Array(-50...50).map { Float($0) }
         let yValues = xValues.map { $0 + (5 * sin($0)) }
-        let scatterPlot = ScatterPlot<Float,Float>(enableGrid: true)
+        var scatterPlot = ScatterPlot<Float,Float>(enableGrid: true)
         scatterPlot.addSeries(xValues, yValues, label: "Plot 1",
                               startColor: .gold, endColor: .blue, scatterPattern: .circle)
         scatterPlot.addSeries(xValues, yValues.map { 2 * $0 + (5 * sin($0)) }, label: "Plot 2",
@@ -29,7 +29,7 @@ extension SubPlotTests {
         
         // LineGraph (function).
         func someFunction(_ x: Float) -> Float { x * x * x }
-        let lineGraph_func = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+        var lineGraph_func = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
         lineGraph_func.addFunction(someFunction,
                               minX: -4.0,
                               maxX: 4.0,
@@ -43,7 +43,7 @@ extension SubPlotTests {
         // LineGraph (data).
         let x:[Float] = [0,100,263,489]
         let y:[Float] = [0,320,310,170]
-        let lineGraph_data = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
+        var lineGraph_data = LineGraph<Float,Float>(enablePrimaryAxisGrid: true)
         lineGraph_data.addSeries(x, y, label: "Plot 1", color: .lightBlue)
         lineGraph_data.plotTitle.title = "PLOT 1"
         lineGraph_data.plotLabel.xLabel = "X-AXIS"


### PR DESCRIPTION
Hopefully this PR will not be _too_ disruptive for GCI participants. AFAIK none of the GCI tasks involve large changes to these parts of the code, so it should be relatively simple for participants to follow along. These changes might even be _easier_ to understand.

This PR does 2 things:

### Stop storing intermediate calculations in plot objects.
We have had bugs where we forgot to clear variables between renders. Rather than store per-render specific things like scaled values in the plots themselves, add a helper `DrawingData` struct for the plot to stash things in. `HasGraphLayout` automatically forwards it.

### Make the plot objects value types.
To enforce that we didn't forget to clear any per-render specific state, make the plots value types. Now, if we saved some calculations in `layoutData(...)`, the compiler would complain that the function has to be `mutating`. This means plots now need to be created with `var`, rather than `let`.

This also allows us to do things like lay-out and rendering plots on background threads, as each plot (really a "plot description") is now a fully-independent value.

These changes are output-neutral - i.e. no changes to reference images are required.