### PR TITLE
Remove [-Wswitch] warning during import

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,6 +17,9 @@
       * [Line Graph with Sub Plots stacked horizontally](#line-graph-with-sub-plots-stacked-horizontally)
       * [Plot functions using LineGraph](#plot-functions-using-linegraph)
       * [Using a secondary axis in LineGraph](#using-a-secondary-axis-in-linegraph)
+    * [Bar Graphs](#bar-graphs)
+      * [Simple Bar Graph](#simple-bar-graph)
+      * [Stacked Bar Graph](#stacked-bar-graph)
     * [Displaying plots in Jupyter Notebook](#displaying-plots-in-jupyter-notebook)
   * [How does this work ?](#how-does-this-work)
   * [Documentation](#documentation)
@@ -102,7 +105,7 @@ Note that because Google Colab doesn't natively support Swift libraries that pro
 Here are some examples to provide you with a headstart to using this library. Here we will be looking at plots using only the AGGRenderer, but the procedure will remain the same for SVGRenderer.
 To use the library in your package, include it as a dependency to your target, in the Package.swift file.
 
-## Line Graphs
+### Line Graphs
 Some sample line graphs
 
 #### Simple Line Graph
@@ -227,6 +230,45 @@ lineGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_r
 The series plotted on the secondary axis are drawn dashed.
 
 <img src="Tests/SwiftPlotTests/Reference/agg/_07_secondary_axis_line_chart.png" width="500">
+
+### Bar Graphs
+Some sample bar graphs
+
+#### Simple Bar Graph
+
+```swift
+import SwiftPlot
+import AGGRenderer
+
+let x:[String] = ["2008","2009","2010","2011"]
+let y:[Float] = [320,-100,420,500]
+
+var barGraph = BarGraph<String,Float>(enableGrid: true)
+barGraph.addSeries(x, y, label: "Plot 1", color: .orange)
+barGraph.plotTitle = PlotTitle("BAR CHART")
+barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
+barGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_renderer)
+```
+<img src="Tests/SwiftPlotTests/Reference/agg/_08_bar_chart.png" width="500">
+
+#### Stacked Bar Graph
+
+```swift
+import SwiftPlot
+import AGGRenderer
+
+let x:[String] = ["2008","2009","2010","2011"]
+let y:[Float] = [320,-100,420,500]
+let y1:[Float] = [100,100,220,245]
+
+var barGraph = BarGraph<String,Float>(enableGrid: true)
+barGraph.addSeries(x, y, label: "Plot 1", color: .orange)
+barGraph.addStackSeries(y1, label: "Plot 2", color: .blue)
+barGraph.plotTitle = PlotTitle("BAR CHART")
+barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
+barGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_renderer)
+```
+<img src="Tests/SwiftPlotTests/Reference/agg/_18_bar_chart_vertical_stacked.png" width="500">
 
 #### Displaying plots in Jupyter Notebook
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,8 @@
     * [Bar Graphs](#bar-graphs)
       * [Simple Bar Graph](#simple-bar-graph)
       * [Stacked Bar Graph](#stacked-bar-graph)
+      * [Horizontal Bar Graph](#horizontal-bar-graph)
+      * [Hatched Bar Graph](#hatched-bar-graph)
     * [Displaying plots in Jupyter Notebook](#displaying-plots-in-jupyter-notebook)
   * [How does this work ?](#how-does-this-work)
   * [Documentation](#documentation)
@@ -269,6 +271,52 @@ barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
 barGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_renderer)
 ```
 <img src="Tests/SwiftPlotTests/Reference/agg/_18_bar_chart_vertical_stacked.png" width="500">
+
+#### Horizontal Bar Graph
+
+```swift
+import SwiftPlot
+import AGGRenderer
+
+let x:[String] = ["2008","2009","2010","2011"]
+let y:[Float] = [320,-100,420,500]
+
+var barGraph = BarGraph<String,Float>(enableGrid: true)
+barGraph.addSeries(x, y, label: "Plot 1", color: .orange, graphOrientation: .horizontal)
+barGraph.plotTitle = PlotTitle("BAR CHART")
+barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
+barGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_renderer)
+```
+<img src="Tests/SwiftPlotTests/Reference/agg/_09_bar_chart_orientation_horizontal.png" width="500">
+
+#### Hatched Bar Graph
+
+```swift
+import SwiftPlot
+import AGGRenderer
+
+let x:[String] = ["2008","2009","2010","2011"]
+let y:[Float] = [320,-100,420,500]
+
+var barGraph = BarGraph<String,Float>(enableGrid: true)
+barGraph.addSeries(x, y, label: "Plot 1", color: .orange, hatchPattern: .grid)
+barGraph.plotTitle = PlotTitle("HATCHED BAR CHART")
+barGraph.plotLabel = PlotLabel(xLabel: "X-AXIS", yLabel: "Y-AXIS")
+barGraph.drawGraphAndOutput(fileName: filePath+"agg/"+fileName, renderer: agg_renderer)
+```
+
+<img src="Tests/SwiftPlotTests/Reference/agg/_14_bar_chart_grid_hatched.png" width="500">
+
+There are many hatched patterns, namely
+- backwardSlash
+- forwardSlash
+- filledCircle
+- hollowCircle
+- cross
+- grid
+- horizontal
+- vertical
+
 
 #### Displaying plots in Jupyter Notebook
 

--- a/README.md
+++ b/README.md
@@ -11,11 +11,12 @@
   * [How to include the library in your package](#how-to-include-the-library-in-your-package)
   * [How to include the library in your Jupyter Notebook](#how-to-include-the-library-in-your-jupyter-notebook)
   * [Examples](#examples)
-    * [Simple Line Graph](#simple-line-graph)
-    * [Line Graph with multiple series of data](#line-graph-with-multiple-series-of-data)
-    * [Line Graph with Sub Plots stacked horizontally](#line-graph-with-sub-plots-stacked-horizontally)
-    * [Plot functions using LineGraph](#plot-functions-using-linegraph)
-    * [Using a secondary axis in LineGraph](#using-a-secondary-axis-in-linegraph)
+    * [Line Graphs](#line-graphs)
+      * [Simple Line Graph](#simple-line-graph)
+      * [Line Graph with multiple series of data](#line-graph-with-multiple-series-of-data)
+      * [Line Graph with Sub Plots stacked horizontally](#line-graph-with-sub-plots-stacked-horizontally)
+      * [Plot functions using LineGraph](#plot-functions-using-linegraph)
+      * [Using a secondary axis in LineGraph](#using-a-secondary-axis-in-linegraph)
     * [Displaying plots in Jupyter Notebook](#displaying-plots-in-jupyter-notebook)
   * [How does this work ?](#how-does-this-work)
   * [Documentation](#documentation)
@@ -100,6 +101,9 @@ Note that because Google Colab doesn't natively support Swift libraries that pro
 ## Examples
 Here are some examples to provide you with a headstart to using this library. Here we will be looking at plots using only the AGGRenderer, but the procedure will remain the same for SVGRenderer.
 To use the library in your package, include it as a dependency to your target, in the Package.swift file.
+
+## Line Graphs
+Some sample line graphs
 
 #### Simple Line Graph
 

--- a/Sources/AGG/include/agg_renderer_markers.h
+++ b/Sources/AGG/include/agg_renderer_markers.h
@@ -46,9 +46,7 @@ namespace agg
         marker_x,
         marker_dash,
         marker_dot,
-        marker_pixel,
-        
-        end_of_markers
+        marker_pixel
     };
 
 

--- a/Sources/AGG/include/agg_renderer_markers.h
+++ b/Sources/AGG/include/agg_renderer_markers.h
@@ -572,6 +572,7 @@ namespace agg
                 case marker_dash:              dash(x, y, r);              break;
                 case marker_dot:               dot(x, y, r);               break;
                 case marker_pixel:             pixel(x, y, r);             break;
+                default:                                                   break;
             }
         }
 


### PR DESCRIPTION
A small commit, but my first to this project nevertheless !

Removed redundant `end_of_markers` case declaration in `AGG/include/agg_renderer_markers.h`, which gets rid of the following warning during import :

```
warning: enumeration value 'end_of_markers' not handled in switch [-Wswitch]
            switch(type)
                   ^
```