### PR TITLE
Include 'agg_renderer_base.h' explicitly in 'agg_blur.h'

### DIFF
--- a/Sources/AGG/include/agg_blur.h
+++ b/Sources/AGG/include/agg_blur.h
@@ -32,6 +32,7 @@
 #include "agg_array.h"
 #include "agg_pixfmt_base.h"
 #include "agg_pixfmt_transposer.h"
+#include "agg_renderer_base.h"
 
 namespace agg
 {


### PR DESCRIPTION
### Fixes #127 

This PR fixes the build on Swift 5.4, apparently a header didn't get included correctly.