### PR TITLE
Cast `outline.tags` to `char *` to fix FreeType 2.13.3 build

### DIFF
--- a/Sources/AGG/agg_font_freetype.cpp
+++ b/Sources/AGG/agg_font_freetype.cpp
@@ -179,7 +179,7 @@ namespace agg
             v_control = v_start;
 
             point = outline.points + first;
-            tags  = outline.tags  + first;
+            tags  = reinterpret_cast<char *>(outline.tags) + first;
             tag   = FT_CURVE_TAG(tags[0]);
 
             // A contour cannot start with a cubic control point!


### PR DESCRIPTION
Unfortunately, AGG no longer builds with FreeType 2.13.3 as `FT_Outline` changed some of its members from `char *` to `unsigned char *` (compare [the 2.13.2 docs](https://web.archive.org/web/20231120104007/https://freetype.org/freetype2/docs/reference/ft2-outline_processing.html) with [the current docs](https://freetype.org/freetype2/docs/reference/ft2-outline_processing.html)):

```
swiftplot/Sources/AGG/agg_font_freetype.cpp:182:35: error: assigning to 'char *' from 'unsigned char *' converts between pointers to integer types where one is of the unique plain 'char' type and the other is not
            tags  = outline.tags  + first;
                    ~~~~~~~~~~~~~~^~~~~~~
```

This PR patches the issue by adding a cast, which should work on both 2.13.2 (or older) and 2.13.3. Once fixed upstream, the AGG sources could be updated.